### PR TITLE
feat: add tag/resource API to Compute (Server) and Volume services

### DIFF
--- a/docs/superpowers/plans/2026-05-17-tag-resource-api-sdk.md
+++ b/docs/superpowers/plans/2026-05-17-tag-resource-api-sdk.md
@@ -1,0 +1,1227 @@
+# Tag/Resource API SDK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ListTags`, `CreateTags`, `UpdateTags` methods to `ComputeServiceV2` (Server) and `VolumeServiceV2`, calling the `/v2/{projectId}/tag/resource/{resourceId}` endpoints from `vserver-api-spec.json`.
+
+**Architecture:** Mirror the existing LoadBalancer tag implementation (`vngcloud/services/loadbalancer/v2/{tag.go, tag_request.go, tag_response.go, url.go}`) into two new locations: `vngcloud/services/compute/v2/` (for Server) and `vngcloud/services/volume/v2/` (for Volume). `UpdateTags` does GET-then-PUT to preserve system tags.
+
+**Tech Stack:** Go 1.x, vngcloud-go-sdk client primitives (`lsclient.IServiceClient`, `lsentity.ListTags`, `lscommon.Tag`).
+
+**Spec:** [docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md](../specs/2026-05-17-tag-resource-api-sdk-design.md)
+
+**Reference implementation:** [vngcloud/services/loadbalancer/v2/tag.go](../../../vngcloud/services/loadbalancer/v2/tag.go), [tag_request.go](../../../vngcloud/services/loadbalancer/v2/tag_request.go), [tag_response.go](../../../vngcloud/services/loadbalancer/v2/tag_response.go), [url.go:146-168](../../../vngcloud/services/loadbalancer/v2/url.go#L146-L168)
+
+---
+
+## Conventions used in this plan
+
+- **TDD via compile-check:** The SDK has no unit-test infrastructure; integration tests in `test/` hit real APIs and require credentials. The "failing test" gate at each task is `go build ./test/...` returning non-zero because the referenced symbols don't exist yet. Once the implementation lands, `go build ./...` and `go vet ./...` must both pass.
+- **Running the integration tests** (with `go test -run ...`) is the developer's manual step after the SDK builds; it requires real `vngcloud` credentials wired through `validSuperSdkConfig()` / `validSdkConfig()`. Don't run them as part of the plan execution.
+- **Test fixture IDs:** hardcoded UUIDs that mirror the existing pattern (e.g. `TestCreateSystemTags` at [test/server_test.go:399](../../../test/server_test.go#L399), `TestListTagsSuccess` at [test/lb_test.go:556](../../../test/lb_test.go#L556)). Developer replaces with valid IDs at runtime.
+- **Commit message format:** `feat: <short summary>` to match existing project history.
+
+---
+
+## Task 1: Compute (Server) `ListTags`
+
+**Files:**
+- Create: `vngcloud/services/compute/v2/tag.go`
+- Create: `vngcloud/services/compute/v2/tag_request.go`
+- Create: `vngcloud/services/compute/v2/tag_response.go`
+- Modify: `vngcloud/services/compute/v2/irequest.go` (append at end)
+- Modify: `vngcloud/services/compute/v2/url.go` (append at end)
+- Modify: `vngcloud/services/compute/icompute.go` (add 1 method to `IComputeServiceV2`)
+- Test: `test/server_test.go` (append at end)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/server_test.go`:
+
+```go
+func TestListServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := lscomputeSvcV2.NewListTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f")
+	tags, sdkErr := vngcloud.VServerGateway().V2().ComputeService().ListTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if tags == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", tags)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewListTagsRequest` or `ListTags` not declared in `lscomputeSvcV2` / on `IComputeServiceV2`.
+
+- [ ] **Step 3: Create the response type**
+
+Write `vngcloud/services/compute/v2/tag_response.go`:
+
+```go
+package v2
+
+import lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+
+type ListTagResponse struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	CreatedAt string `json:"createdAt"`
+	SystemTag bool   `json:"systemTag,omitempty"`
+}
+
+type ListTagsResponse []ListTagResponse
+
+func (s ListTagResponse) ToEntityTag() *lsentity.Tag {
+	return &lsentity.Tag{
+		Key:       s.Key,
+		Value:     s.Value,
+		SystemTag: s.SystemTag,
+	}
+}
+
+func (s *ListTagsResponse) ToEntityListTags() *lsentity.ListTags {
+	result := new(lsentity.ListTags)
+	if s == nil {
+		return result
+	}
+
+	for _, item := range *s {
+		result.Add(item.ToEntityTag())
+	}
+
+	return result
+}
+```
+
+- [ ] **Step 4: Create the request struct + constructor**
+
+Write `vngcloud/services/compute/v2/tag_request.go`:
+
+```go
+package v2
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+const (
+	serverResourceType = "SERVER"
+)
+
+func NewListTagsRequest(pserverId string) IListTagsRequest {
+	o := new(ListTagsRequest)
+	o.ServerId = pserverId
+	return o
+}
+
+func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+type ListTagsRequest struct {
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+```
+
+- [ ] **Step 5: Add the request interface**
+
+Append to `vngcloud/services/compute/v2/irequest.go` (at end of file, before the closing of the file):
+
+```go
+
+type IListTagsRequest interface {
+	GetServerId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListTagsRequest
+}
+```
+
+- [ ] **Step 6: Add the URL builder**
+
+Append to `vngcloud/services/compute/v2/url.go`:
+
+```go
+
+func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}
+```
+
+- [ ] **Step 7: Add the service method**
+
+Write `vngcloud/services/compute/v2/tag.go`:
+
+```go
+package v2
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+func (s *ComputeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, lserr.IError) {
+	url := listTagsUrl(s.VServerClient, popts)
+	resp := new(ListTagsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return resp.ToEntityListTags(), nil
+}
+```
+
+- [ ] **Step 8: Register the method on the public interface**
+
+Modify `vngcloud/services/compute/icompute.go` — add this line to the `IComputeServiceV2` interface block (keep alphabetical-ish placement; near the existing `CreateServerGroup` lines is fine):
+
+```go
+	ListTags(popts lscomputeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
+```
+
+- [ ] **Step 9: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0, no errors.
+
+Run: `go vet ./...`
+Expected: exit 0, no warnings.
+
+Run: `go build ./test/...`
+Expected: exit 0 (test file compiles, even if not run).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add vngcloud/services/compute/v2/tag.go \
+        vngcloud/services/compute/v2/tag_request.go \
+        vngcloud/services/compute/v2/tag_response.go \
+        vngcloud/services/compute/v2/irequest.go \
+        vngcloud/services/compute/v2/url.go \
+        vngcloud/services/compute/icompute.go \
+        test/server_test.go
+git commit -m "feat: add ListTags to ComputeServiceV2 (server tag/resource API)"
+```
+
+---
+
+## Task 2: Compute (Server) `CreateTags`
+
+**Files:**
+- Modify: `vngcloud/services/compute/v2/tag.go` (append)
+- Modify: `vngcloud/services/compute/v2/tag_request.go` (append)
+- Modify: `vngcloud/services/compute/v2/irequest.go` (append)
+- Modify: `vngcloud/services/compute/v2/url.go` (append)
+- Modify: `vngcloud/services/compute/icompute.go` (1 line)
+- Test: `test/server_test.go` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/server_test.go`:
+
+```go
+func TestCreateServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := lscomputeSvcV2.NewCreateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").
+		WithTags("env", "dev")
+	sdkErr := vngcloud.VServerGateway().V2().ComputeService().CreateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewCreateTagsRequest` or `CreateTags` not declared.
+
+- [ ] **Step 3: Extend the request file**
+
+Append to `vngcloud/services/compute/v2/tag_request.go`:
+
+```go
+
+func NewCreateTagsRequest(pserverId string) ICreateTagsRequest {
+	opts := new(CreateTagsRequest)
+	opts.ServerId = pserverId
+	opts.ResourceID = pserverId
+	opts.ResourceType = serverResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type CreateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *CreateTagsRequest) ToRequestBody() interface{} {
+	return s
+}
+
+func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Add the request interface**
+
+Append to `vngcloud/services/compute/v2/irequest.go`:
+
+```go
+
+type ICreateTagsRequest interface {
+	GetServerId() string
+	ToRequestBody() interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) ICreateTagsRequest
+	AddUserAgent(pagent ...string) ICreateTagsRequest
+}
+```
+
+- [ ] **Step 5: Add the URL builder**
+
+Append to `vngcloud/services/compute/v2/url.go`:
+
+```go
+
+func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}
+```
+
+- [ ] **Step 6: Add the service method**
+
+Append to `vngcloud/services/compute/v2/tag.go`:
+
+```go
+
+func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
+	url := createTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody()).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 7: Register the method on the public interface**
+
+In `vngcloud/services/compute/icompute.go`, add to the `IComputeServiceV2` block, immediately after the `ListTags` line from Task 1:
+
+```go
+	CreateTags(popts lscomputeSvcV2.ICreateTagsRequest) lserr.IError
+```
+
+- [ ] **Step 8: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+Run: `go build ./test/...`
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vngcloud/services/compute/v2/tag.go \
+        vngcloud/services/compute/v2/tag_request.go \
+        vngcloud/services/compute/v2/irequest.go \
+        vngcloud/services/compute/v2/url.go \
+        vngcloud/services/compute/icompute.go \
+        test/server_test.go
+git commit -m "feat: add CreateTags to ComputeServiceV2 (server tag/resource API)"
+```
+
+---
+
+## Task 3: Compute (Server) `UpdateTags`
+
+**Files:**
+- Modify: `vngcloud/services/compute/v2/tag.go` (append)
+- Modify: `vngcloud/services/compute/v2/tag_request.go` (append)
+- Modify: `vngcloud/services/compute/v2/irequest.go` (append)
+- Modify: `vngcloud/services/compute/v2/url.go` (append)
+- Modify: `vngcloud/services/compute/icompute.go` (1 line)
+- Test: `test/server_test.go` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/server_test.go`:
+
+```go
+func TestUpdateServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := lscomputeSvcV2.NewUpdateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").
+		WithTags("env", "prod")
+	sdkErr := vngcloud.VServerGateway().V2().ComputeService().UpdateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewUpdateTagsRequest` or `UpdateTags` not declared.
+
+- [ ] **Step 3: Add the request struct + constructor**
+
+Append to `vngcloud/services/compute/v2/tag_request.go`:
+
+```go
+
+func NewUpdateTagsRequest(pserverId string) IUpdateTagsRequest {
+	opts := new(UpdateTagsRequest)
+	opts.ServerId = pserverId
+	opts.ResourceID = pserverId
+	opts.ResourceType = serverResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type UpdateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
+	st := map[string]lscommon.Tag{}
+	for _, tag := range plstTags.Items {
+		st[tag.Key] = lscommon.Tag{
+			IsEdited: false,
+			Key:      tag.Key,
+			Value:    tag.Value,
+		}
+	}
+
+	for _, tag := range s.TagRequestList {
+		st[tag.Key] = tag
+	}
+
+	s.TagRequestList = make([]lscommon.Tag, 0)
+	for _, tag := range st {
+		s.TagRequestList = append(s.TagRequestList, tag)
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) WithTags(ptags ...string) IUpdateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) ToMap() map[string]interface{} {
+	res := make(map[string]interface{})
+	for _, tag := range s.TagRequestList {
+		res[tag.Key] = tag.Value
+	}
+	return res
+}
+```
+
+Also update the file's import block at the top — add `lsentity` next to `lscommon`:
+
+```go
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+```
+
+- [ ] **Step 4: Add the request interface**
+
+Append to `vngcloud/services/compute/v2/irequest.go`:
+
+```go
+
+type IUpdateTagsRequest interface {
+	GetServerId() string
+	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) IUpdateTagsRequest
+	ToMap() map[string]interface{}
+	AddUserAgent(pagent ...string) IUpdateTagsRequest
+}
+```
+
+Also update the import block at the top of `irequest.go` to add the `lsentity` import (if not already present):
+
+```go
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+```
+
+If `irequest.go` previously had no imports, change the file to start with the import above immediately under the `package v2` line.
+
+- [ ] **Step 5: Add the URL builder**
+
+Append to `vngcloud/services/compute/v2/url.go`:
+
+```go
+
+func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}
+```
+
+- [ ] **Step 6: Add the service method**
+
+Append to `vngcloud/services/compute/v2/tag.go`:
+
+```go
+
+func (s *ComputeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetServerId()))
+	if sdkErr != nil {
+		return sdkErr
+	}
+
+	// Do not update system tags
+	tags := new(lsentity.ListTags)
+	for _, tag := range tmpTags.Items {
+		if !tag.SystemTag {
+			tags.Items = append(tags.Items, tag)
+		}
+	}
+
+	url := updateTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody(tags)).
+		WithJsonError(errResp)
+
+	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp,
+			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 7: Register the method on the public interface**
+
+In `vngcloud/services/compute/icompute.go`, add to the `IComputeServiceV2` block, immediately after the `CreateTags` line from Task 2:
+
+```go
+	UpdateTags(popts lscomputeSvcV2.IUpdateTagsRequest) lserr.IError
+```
+
+- [ ] **Step 8: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+Run: `go build ./test/...`
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vngcloud/services/compute/v2/tag.go \
+        vngcloud/services/compute/v2/tag_request.go \
+        vngcloud/services/compute/v2/irequest.go \
+        vngcloud/services/compute/v2/url.go \
+        vngcloud/services/compute/icompute.go \
+        test/server_test.go
+git commit -m "feat: add UpdateTags to ComputeServiceV2 (server tag/resource API)"
+```
+
+---
+
+## Task 4: Volume `ListTags`
+
+**Files:**
+- Create: `vngcloud/services/volume/v2/tag.go`
+- Create: `vngcloud/services/volume/v2/tag_request.go`
+- Create: `vngcloud/services/volume/v2/tag_response.go`
+- Modify: `vngcloud/services/volume/v2/irequest.go` (append)
+- Modify: `vngcloud/services/volume/v2/url.go` (append)
+- Modify: `vngcloud/services/volume/ivolume.go` (add 1 method to `IVolumeServiceV2`)
+- Test: `test/volume_test.go` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/volume_test.go` (note the existing import alias is `v2`, not `lsvolumeSvcV2`):
+
+```go
+func TestListVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := v2.NewListTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	tags, sdkErr := vngcloud.VServerGateway().V2().VolumeService().ListTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if tags == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", tags)
+	t.Log("PASS")
+}
+```
+
+If `validSuperSdkConfig` is not imported in `test/volume_test.go` already, no action — `test/` is a single package; helpers are in scope across files.
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewListTagsRequest` or `ListTags` not declared in `v2` package / on `IVolumeServiceV2`.
+
+- [ ] **Step 3: Create the response type**
+
+Write `vngcloud/services/volume/v2/tag_response.go`:
+
+```go
+package v2
+
+import lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+
+type ListTagResponse struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	CreatedAt string `json:"createdAt"`
+	SystemTag bool   `json:"systemTag,omitempty"`
+}
+
+type ListTagsResponse []ListTagResponse
+
+func (s ListTagResponse) ToEntityTag() *lsentity.Tag {
+	return &lsentity.Tag{
+		Key:       s.Key,
+		Value:     s.Value,
+		SystemTag: s.SystemTag,
+	}
+}
+
+func (s *ListTagsResponse) ToEntityListTags() *lsentity.ListTags {
+	result := new(lsentity.ListTags)
+	if s == nil {
+		return result
+	}
+
+	for _, item := range *s {
+		result.Add(item.ToEntityTag())
+	}
+
+	return result
+}
+```
+
+- [ ] **Step 4: Create the request struct + constructor**
+
+Write `vngcloud/services/volume/v2/tag_request.go`:
+
+```go
+package v2
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+const (
+	volumeResourceType = "VOLUME"
+)
+
+func NewListTagsRequest(pvolumeId string) IListTagsRequest {
+	o := new(ListTagsRequest)
+	o.BlockVolumeId = pvolumeId
+	return o
+}
+
+func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+type ListTagsRequest struct {
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}
+```
+
+- [ ] **Step 5: Add the request interface**
+
+Append to `vngcloud/services/volume/v2/irequest.go`:
+
+```go
+
+type IListTagsRequest interface {
+	GetBlockVolumeId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListTagsRequest
+}
+```
+
+- [ ] **Step 6: Add the URL builder**
+
+Append to `vngcloud/services/volume/v2/url.go`:
+
+```go
+
+func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}
+```
+
+- [ ] **Step 7: Add the service method**
+
+Write `vngcloud/services/volume/v2/tag.go`:
+
+```go
+package v2
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+func (s *VolumeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, lserr.IError) {
+	url := listTagsUrl(s.VServerClient, popts)
+	resp := new(ListTagsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return resp.ToEntityListTags(), nil
+}
+```
+
+- [ ] **Step 8: Register the method on the public interface**
+
+In `vngcloud/services/volume/ivolume.go`, add this line inside the `IVolumeServiceV2` block (alongside `MigrateBlockVolumeById`):
+
+```go
+	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
+```
+
+- [ ] **Step 9: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+Run: `go build ./test/...`
+Expected: exit 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add vngcloud/services/volume/v2/tag.go \
+        vngcloud/services/volume/v2/tag_request.go \
+        vngcloud/services/volume/v2/tag_response.go \
+        vngcloud/services/volume/v2/irequest.go \
+        vngcloud/services/volume/v2/url.go \
+        vngcloud/services/volume/ivolume.go \
+        test/volume_test.go
+git commit -m "feat: add ListTags to VolumeServiceV2 (volume tag/resource API)"
+```
+
+---
+
+## Task 5: Volume `CreateTags`
+
+**Files:**
+- Modify: `vngcloud/services/volume/v2/tag.go` (append)
+- Modify: `vngcloud/services/volume/v2/tag_request.go` (append)
+- Modify: `vngcloud/services/volume/v2/irequest.go` (append)
+- Modify: `vngcloud/services/volume/v2/url.go` (append)
+- Modify: `vngcloud/services/volume/ivolume.go` (1 line)
+- Test: `test/volume_test.go` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/volume_test.go`:
+
+```go
+func TestCreateVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := v2.NewCreateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").
+		WithTags("env", "dev")
+	sdkErr := vngcloud.VServerGateway().V2().VolumeService().CreateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewCreateTagsRequest` or `CreateTags` not declared.
+
+- [ ] **Step 3: Extend the request file**
+
+Append to `vngcloud/services/volume/v2/tag_request.go`:
+
+```go
+
+func NewCreateTagsRequest(pvolumeId string) ICreateTagsRequest {
+	opts := new(CreateTagsRequest)
+	opts.BlockVolumeId = pvolumeId
+	opts.ResourceID = pvolumeId
+	opts.ResourceType = volumeResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type CreateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}
+
+func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *CreateTagsRequest) ToRequestBody() interface{} {
+	return s
+}
+
+func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Add the request interface**
+
+Append to `vngcloud/services/volume/v2/irequest.go`:
+
+```go
+
+type ICreateTagsRequest interface {
+	GetBlockVolumeId() string
+	ToRequestBody() interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) ICreateTagsRequest
+	AddUserAgent(pagent ...string) ICreateTagsRequest
+}
+```
+
+- [ ] **Step 5: Add the URL builder**
+
+Append to `vngcloud/services/volume/v2/url.go`:
+
+```go
+
+func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}
+```
+
+- [ ] **Step 6: Add the service method**
+
+Append to `vngcloud/services/volume/v2/tag.go`:
+
+```go
+
+func (s *VolumeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
+	url := createTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody()).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 7: Register the method on the public interface**
+
+In `vngcloud/services/volume/ivolume.go`, add to the `IVolumeServiceV2` block, immediately after the `ListTags` line from Task 4:
+
+```go
+	CreateTags(popts lsvolumeSvcV2.ICreateTagsRequest) lserr.IError
+```
+
+- [ ] **Step 8: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+Run: `go build ./test/...`
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vngcloud/services/volume/v2/tag.go \
+        vngcloud/services/volume/v2/tag_request.go \
+        vngcloud/services/volume/v2/irequest.go \
+        vngcloud/services/volume/v2/url.go \
+        vngcloud/services/volume/ivolume.go \
+        test/volume_test.go
+git commit -m "feat: add CreateTags to VolumeServiceV2 (volume tag/resource API)"
+```
+
+---
+
+## Task 6: Volume `UpdateTags`
+
+**Files:**
+- Modify: `vngcloud/services/volume/v2/tag.go` (append)
+- Modify: `vngcloud/services/volume/v2/tag_request.go` (append)
+- Modify: `vngcloud/services/volume/v2/irequest.go` (append)
+- Modify: `vngcloud/services/volume/v2/url.go` (append)
+- Modify: `vngcloud/services/volume/ivolume.go` (1 line)
+- Test: `test/volume_test.go` (append)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/volume_test.go`:
+
+```go
+func TestUpdateVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := v2.NewUpdateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").
+		WithTags("env", "prod")
+	sdkErr := vngcloud.VServerGateway().V2().VolumeService().UpdateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewUpdateTagsRequest` or `UpdateTags` not declared.
+
+- [ ] **Step 3: Add the request struct + constructor + builders**
+
+Update the import block at the top of `vngcloud/services/volume/v2/tag_request.go` to add `lsentity`:
+
+```go
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+```
+
+Append to `vngcloud/services/volume/v2/tag_request.go`:
+
+```go
+
+func NewUpdateTagsRequest(pvolumeId string) IUpdateTagsRequest {
+	opts := new(UpdateTagsRequest)
+	opts.BlockVolumeId = pvolumeId
+	opts.ResourceID = pvolumeId
+	opts.ResourceType = volumeResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type UpdateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}
+
+func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
+	st := map[string]lscommon.Tag{}
+	for _, tag := range plstTags.Items {
+		st[tag.Key] = lscommon.Tag{
+			IsEdited: false,
+			Key:      tag.Key,
+			Value:    tag.Value,
+		}
+	}
+
+	for _, tag := range s.TagRequestList {
+		st[tag.Key] = tag
+	}
+
+	s.TagRequestList = make([]lscommon.Tag, 0)
+	for _, tag := range st {
+		s.TagRequestList = append(s.TagRequestList, tag)
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) WithTags(ptags ...string) IUpdateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) ToMap() map[string]interface{} {
+	res := make(map[string]interface{})
+	for _, tag := range s.TagRequestList {
+		res[tag.Key] = tag.Value
+	}
+	return res
+}
+```
+
+- [ ] **Step 4: Add the request interface**
+
+Update the import block at the top of `vngcloud/services/volume/v2/irequest.go` to add `lsentity` (if not already present from Task 4 — it was not):
+
+```go
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+```
+
+Append to `vngcloud/services/volume/v2/irequest.go`:
+
+```go
+
+type IUpdateTagsRequest interface {
+	GetBlockVolumeId() string
+	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) IUpdateTagsRequest
+	ToMap() map[string]interface{}
+	AddUserAgent(pagent ...string) IUpdateTagsRequest
+}
+```
+
+- [ ] **Step 5: Add the URL builder**
+
+Append to `vngcloud/services/volume/v2/url.go`:
+
+```go
+
+func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}
+```
+
+- [ ] **Step 6: Add the service method**
+
+Append to `vngcloud/services/volume/v2/tag.go`:
+
+```go
+
+func (s *VolumeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetBlockVolumeId()))
+	if sdkErr != nil {
+		return sdkErr
+	}
+
+	// Do not update system tags
+	tags := new(lsentity.ListTags)
+	for _, tag := range tmpTags.Items {
+		if !tag.SystemTag {
+			tags.Items = append(tags.Items, tag)
+		}
+	}
+
+	url := updateTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody(tags)).
+		WithJsonError(errResp)
+
+	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp,
+			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 7: Register the method on the public interface**
+
+In `vngcloud/services/volume/ivolume.go`, add to the `IVolumeServiceV2` block, immediately after the `CreateTags` line from Task 5:
+
+```go
+	UpdateTags(popts lsvolumeSvcV2.IUpdateTagsRequest) lserr.IError
+```
+
+- [ ] **Step 8: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+Run: `go build ./test/...`
+Expected: exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vngcloud/services/volume/v2/tag.go \
+        vngcloud/services/volume/v2/tag_request.go \
+        vngcloud/services/volume/v2/irequest.go \
+        vngcloud/services/volume/v2/url.go \
+        vngcloud/services/volume/ivolume.go \
+        test/volume_test.go
+git commit -m "feat: add UpdateTags to VolumeServiceV2 (volume tag/resource API)"
+```
+
+---
+
+## Final verification (post Task 6)
+
+- [ ] **Run the full build + vet one last time**
+
+Run: `go build ./...`
+Expected: exit 0.
+
+Run: `go vet ./...`
+Expected: exit 0.
+
+- [ ] **Optional: run the integration tests (requires real credentials)**
+
+These tests hit the live vserver gateway. Replace the hardcoded resource IDs in each new test with IDs from a live project before running.
+
+Run any of:
+
+```
+go test -v -run TestListServerTagsSuccess ./test/...
+go test -v -run TestCreateServerTagsSuccess ./test/...
+go test -v -run TestUpdateServerTagsSuccess ./test/...
+go test -v -run TestListVolumeTagsSuccess ./test/...
+go test -v -run TestCreateVolumeTagsSuccess ./test/...
+go test -v -run TestUpdateVolumeTagsSuccess ./test/...
+```
+
+Expected: PASS, logged tag list / `nil` sdkErr. Failures here indicate live-environment issues, not code defects — investigate API response separately.

--- a/docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md
+++ b/docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md
@@ -307,15 +307,17 @@ Six new test functions to add:
 
 ```go
 // test/server_test.go
-func TestListServerTags(t *testing.T)     { ... }
-func TestCreateServerTags(t *testing.T)   { ... }
-func TestUpdateServerTags(t *testing.T)   { ... }
+func TestListServerTags(t *ltesting.T)     { ... }
+func TestCreateServerTags(t *ltesting.T)   { ... }
+func TestUpdateServerTags(t *ltesting.T)   { ... }
 
 // test/volume_test.go
-func TestListVolumeTags(t *testing.T)     { ... }
-func TestCreateVolumeTags(t *testing.T)   { ... }
-func TestUpdateVolumeTags(t *testing.T)   { ... }
+func TestListVolumeTags(t *ltesting.T)     { ... }
+func TestCreateVolumeTags(t *ltesting.T)   { ... }
+func TestUpdateVolumeTags(t *ltesting.T)   { ... }
 ```
+
+(`ltesting "testing"` is the aliased import used throughout the existing `test/` package.)
 
 Each test: build request via `NewXxxTagsRequest(resourceId).WithTags(...)`, call the service method, log result, expect `sdkerr == nil`. Resource IDs are hardcoded fixtures matching the existing test style.
 

--- a/docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md
+++ b/docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md
@@ -1,0 +1,347 @@
+# Design — Add `tag/resource/{resourceId}` API support to Compute (Server) and Volume services
+
+**Date:** 2026-05-17
+**Status:** Approved for implementation planning
+**Author:** tytv2
+
+## Background
+
+`vserver-api-spec.json` declares two endpoints for managing tags on a resource:
+
+| Verb | Path | Operation |
+|------|------|-----------|
+| `GET` | `/v2/{projectId}/tag/resource/{resourceId}` | List tags of a resource |
+| `PUT` | `/v2/{projectId}/tag/resource/{resourceId}` | Replace tag list on a resource (`resourceType` in body distinguishes Server / Volume / LoadBalancer) |
+
+The SDK currently implements these endpoints **only for LoadBalancer** ([`vngcloud/services/loadbalancer/v2/tag.go`](../../../vngcloud/services/loadbalancer/v2/tag.go), [`url.go`](../../../vngcloud/services/loadbalancer/v2/url.go)). Server and Volume have no equivalents:
+
+- Server v1 has `ServerServiceInternalV1.CreateSystemTags` ([`systemtag.go`](../../../vngcloud/services/server/v1/systemtag.go)) — calls a different endpoint, `POST /<projectId>/tags`, not the spec endpoint above.
+- Volume only supports inline tags on `CreateBlockVolume` via `WithTags` ([`blockvolume_request.go:250`](../../../vngcloud/services/volume/v2/blockvolume_request.go#L250)) — no per-resource tag list management.
+
+## Goal
+
+Add three methods — `ListTags`, `CreateTags`, `UpdateTags` — to both `ComputeServiceV2` (which manages Server resources) and `VolumeServiceV2`, mirroring the LoadBalancer pattern exactly.
+
+## Non-goals
+
+- Refactoring the existing LoadBalancer tag implementation.
+- Touching `ServerServiceInternalV1.CreateSystemTags` (legacy endpoint, kept as-is).
+- Adding a `DeleteTags` method (no DELETE endpoint exists for `/tag/resource/`).
+- Introducing a generic shared tag service or refactoring tag code across services.
+
+## Architecture
+
+### File layout
+
+```
+vngcloud/services/compute/v2/
+├── tag.go                # 3 service methods on ComputeServiceV2
+├── tag_request.go        # request structs + builders
+└── tag_response.go       # response struct + entity mapping
+
+vngcloud/services/volume/v2/
+├── tag.go                # 3 service methods on VolumeServiceV2
+├── tag_request.go
+└── tag_response.go
+```
+
+### Files to modify
+
+- `vngcloud/services/compute/icompute.go` — add 3 methods to `IComputeServiceV2`.
+- `vngcloud/services/compute/v2/irequest.go` — add `IListTagsRequest`, `ICreateTagsRequest`, `IUpdateTagsRequest`.
+- `vngcloud/services/compute/v2/url.go` — add `listTagsUrl`, `createTagsUrl`, `updateTagsUrl`.
+- `vngcloud/services/volume/ivolume.go` — add 3 methods to `IVolumeServiceV2`.
+- `vngcloud/services/volume/v2/irequest.go` — add 3 tag request interfaces.
+- `vngcloud/services/volume/v2/url.go` — add 3 URL builders.
+
+### Files NOT modified
+
+- `vngcloud/services/loadbalancer/v2/*` — LB tag code stays as-is.
+- `vngcloud/services/server/v1/systemtag*` — legacy `CreateSystemTags` stays.
+
+## Public API
+
+```go
+// Server tags
+vngcloud.VServerGateway().V2().ComputeService().ListTags(
+    lscomputeV2.NewListTagsRequest(serverId))
+
+vngcloud.VServerGateway().V2().ComputeService().CreateTags(
+    lscomputeV2.NewCreateTagsRequest(serverId).WithTags("env", "prod"))
+
+vngcloud.VServerGateway().V2().ComputeService().UpdateTags(
+    lscomputeV2.NewUpdateTagsRequest(serverId).WithTags("env", "prod"))
+
+// Volume tags
+vngcloud.VServerGateway().V2().VolumeService().ListTags(
+    lsvolumeV2.NewListTagsRequest(volumeId))
+
+vngcloud.VServerGateway().V2().VolumeService().CreateTags(
+    lsvolumeV2.NewCreateTagsRequest(volumeId).WithTags("env", "prod"))
+
+vngcloud.VServerGateway().V2().VolumeService().UpdateTags(
+    lsvolumeV2.NewUpdateTagsRequest(volumeId).WithTags("env", "prod"))
+```
+
+## Component design
+
+### URL builders
+
+All three methods hit the same path; only the HTTP verb differs.
+
+```go
+// compute/v2/url.go
+func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
+    return psc.ServiceURL(psc.GetProjectId(), "tag", "resource", popts.GetServerId())
+}
+func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
+    return psc.ServiceURL(psc.GetProjectId(), "tag", "resource", popts.GetServerId())
+}
+func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
+    return psc.ServiceURL(psc.GetProjectId(), "tag", "resource", popts.GetServerId())
+}
+```
+
+Volume version is identical, with `popts.GetBlockVolumeId()` instead.
+
+### Request structs
+
+```go
+// compute/v2/tag_request.go (Volume mirrors with BlockVolumeCommon and "VOLUME")
+
+const serverResourceType = "SERVER"
+
+func NewListTagsRequest(pserverId string) IListTagsRequest {
+    o := new(ListTagsRequest)
+    o.ServerId = pserverId
+    return o
+}
+
+func NewCreateTagsRequest(pserverId string) ICreateTagsRequest {
+    o := new(CreateTagsRequest)
+    o.ServerId = pserverId
+    o.ResourceID = pserverId
+    o.ResourceType = serverResourceType
+    o.TagRequestList = make([]lscommon.Tag, 0)
+    return o
+}
+
+func NewUpdateTagsRequest(pserverId string) IUpdateTagsRequest {
+    o := new(UpdateTagsRequest)
+    o.ServerId = pserverId
+    o.ResourceID = pserverId
+    o.ResourceType = serverResourceType
+    o.TagRequestList = make([]lscommon.Tag, 0)
+    return o
+}
+
+type ListTagsRequest struct {
+    lscommon.UserAgent
+    lscommon.ServerCommon  // exposes GetServerId()
+}
+
+type CreateTagsRequest struct {
+    ResourceID     string         `json:"resourceId"`
+    ResourceType   string         `json:"resourceType"`
+    TagRequestList []lscommon.Tag `json:"tagRequestList"`
+    lscommon.UserAgent
+    lscommon.ServerCommon
+}
+
+type UpdateTagsRequest struct {
+    ResourceID     string         `json:"resourceId"`
+    ResourceType   string         `json:"resourceType"`
+    TagRequestList []lscommon.Tag `json:"tagRequestList"`
+    lscommon.UserAgent
+    lscommon.ServerCommon
+}
+```
+
+Plus the following builder methods on each struct, copied verbatim in shape from LB ([`loadbalancer/v2/tag_request.go`](../../../vngcloud/services/loadbalancer/v2/tag_request.go)):
+
+- `AddUserAgent(pagent ...string)`
+- `(*CreateTagsRequest).WithTags(ptags ...string)`
+- `(*CreateTagsRequest).ToRequestBody() interface{}`
+- `(*UpdateTagsRequest).WithTags(ptags ...string)`
+- `(*UpdateTagsRequest).ToRequestBody(plstTags *lsentity.ListTags) interface{}` — implements system-tag preservation via dedup map
+- `(*UpdateTagsRequest).ToMap() map[string]interface{}`
+
+### Interfaces
+
+```go
+// compute/v2/irequest.go
+type IListTagsRequest interface {
+    GetServerId() string
+    ParseUserAgent() string
+    AddUserAgent(pagent ...string) IListTagsRequest
+}
+
+type ICreateTagsRequest interface {
+    GetServerId() string
+    ToRequestBody() interface{}
+    ParseUserAgent() string
+    WithTags(ptags ...string) ICreateTagsRequest
+    AddUserAgent(pagent ...string) ICreateTagsRequest
+}
+
+type IUpdateTagsRequest interface {
+    GetServerId() string
+    ToRequestBody(plstTags *lsentity.ListTags) interface{}
+    ParseUserAgent() string
+    WithTags(ptags ...string) IUpdateTagsRequest
+    ToMap() map[string]interface{}
+    AddUserAgent(pagent ...string) IUpdateTagsRequest
+}
+```
+
+Volume interfaces are identical except `GetServerId() string` is replaced by `GetBlockVolumeId() string`.
+
+### Response
+
+```go
+// compute/v2/tag_response.go (Volume identical, just different package)
+
+type ListTagResponse struct {
+    Key       string `json:"key"`
+    Value     string `json:"value"`
+    CreatedAt string `json:"createdAt"`
+    SystemTag bool   `json:"systemTag,omitempty"`
+}
+type ListTagsResponse []ListTagResponse
+
+func (s ListTagResponse) ToEntityTag() *lsentity.Tag {
+    return &lsentity.Tag{Key: s.Key, Value: s.Value, SystemTag: s.SystemTag}
+}
+func (s *ListTagsResponse) ToEntityListTags() *lsentity.ListTags {
+    result := new(lsentity.ListTags)
+    if s == nil {
+        return result
+    }
+    for _, item := range *s {
+        result.Add(item.ToEntityTag())
+    }
+    return result
+}
+```
+
+### Service methods
+
+```go
+// compute/v2/tag.go
+func (s *ComputeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, lserr.IError) {
+    url := listTagsUrl(s.VServerClient, popts)
+    resp := new(ListTagsResponse)
+    errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+    req := lsclient.NewRequest().
+        WithHeader("User-Agent", popts.ParseUserAgent()).
+        WithOkCodes(200).
+        WithJsonResponse(resp).
+        WithJsonError(errResp)
+    if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+        return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+    }
+    return resp.ToEntityListTags(), nil
+}
+
+func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
+    url := createTagsUrl(s.VServerClient, popts)
+    errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+    req := lsclient.NewRequest().
+        WithHeader("User-Agent", popts.ParseUserAgent()).
+        WithOkCodes(200).
+        WithJsonBody(popts.ToRequestBody()).
+        WithJsonError(errResp)
+    if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
+        return lserr.SdkErrorHandler(sdkErr, errResp)
+    }
+    return nil
+}
+
+func (s *ComputeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+    tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetServerId()))
+    if sdkErr != nil {
+        return sdkErr
+    }
+    tags := new(lsentity.ListTags)
+    for _, tag := range tmpTags.Items {
+        if !tag.SystemTag {
+            tags.Items = append(tags.Items, tag)
+        }
+    }
+    url := updateTagsUrl(s.VServerClient, popts)
+    errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+    req := lsclient.NewRequest().
+        WithHeader("User-Agent", popts.ParseUserAgent()).
+        WithOkCodes(200).
+        WithJsonBody(popts.ToRequestBody(tags)).
+        WithJsonError(errResp)
+    if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
+        return lserr.SdkErrorHandler(sdkErr, errResp,
+            lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
+    }
+    return nil
+}
+```
+
+Volume version is character-for-character identical except: package `v2` of volume, `popts.GetBlockVolumeId()` instead of `popts.GetServerId()`, and the inner `NewListTagsRequest` reference resolves inside the volume package.
+
+## Method semantics
+
+| Method | HTTP | System-tag behavior | When to use |
+|---|---|---|---|
+| `ListTags` | `GET` | Returns both system and user tags (caller can filter via `tag.SystemTag`). | Read tag list of a resource. |
+| `CreateTags` | `PUT` | **Replaces the entire tag list** — system tags are wiped unless caller includes them. | Only when caller fully owns the tag list and accepts data loss risk. |
+| `UpdateTags` | `PUT` | Internally `GET`s current list, filters out system tags, merges caller's tags via dedupe-by-key, then `PUT`s. Safe — preserves system tags. | **Default recommended method** for adding/updating user tags. |
+
+`UpdateTags` semantics match LB's `UpdateTags` exactly: empty `WithTags` clears all user tags but keeps system tags.
+
+## Constants reuse
+
+Resource-type constants `"SERVER"`, `"VOLUME"`, `"LOAD-BALANCER"` are already defined in [`server/v1/systemtag_request.go:6-9`](../../../vngcloud/services/server/v1/systemtag_request.go#L6-L9). They are **not reused** here — each new package defines a local `const serverResourceType = "SERVER"` (or `volumeResourceType = "VOLUME"`) to avoid creating a reverse dependency from `compute/v2` or `volume/v2` to `server/v1`. The string values match.
+
+## Testing
+
+Integration tests against the real API (matches existing SDK test pattern — e.g. `TestCreateSystemTags` at [`test/server_test.go:399`](../../../test/server_test.go#L399), and LB's `TestListTags`/`TestCreateTags`/`TestUpdateTags` in [`test/lb_test.go`](../../../test/lb_test.go)).
+
+Six new test functions to add:
+
+```go
+// test/server_test.go
+func TestListServerTags(t *testing.T)     { ... }
+func TestCreateServerTags(t *testing.T)   { ... }
+func TestUpdateServerTags(t *testing.T)   { ... }
+
+// test/volume_test.go
+func TestListVolumeTags(t *testing.T)     { ... }
+func TestCreateVolumeTags(t *testing.T)   { ... }
+func TestUpdateVolumeTags(t *testing.T)   { ... }
+```
+
+Each test: build request via `NewXxxTagsRequest(resourceId).WithTags(...)`, call the service method, log result, expect `sdkerr == nil`. Resource IDs are hardcoded fixtures matching the existing test style.
+
+No unit tests with HTTP mocks (SDK has no such pattern).
+
+## Error handling
+
+- `ListTags`, `CreateTags`: `lserr.NormalErrorType`, no extra error helpers.
+- `UpdateTags`: `lserr.NormalErrorType` plus `lserr.WithErrorTagKeyInvalid(errResp)` — mirrors LB's `UpdateTags`. Existing helper, no new helper added.
+- If implementation surfaces vserver-tag-API-specific error codes not present in LB, new `lserr.WithError*` helpers may be added; default is to reuse existing ones.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| `UpdateTags` with empty `WithTags` | `ListTags` → filter system → empty user list → `PUT` replaces user tags with empty → resource has only system tags. Correct "clear all user tags" semantics. |
+| `WithTags` with odd number of args | Appends `"none"` as the missing value (matches LB at [`loadbalancer/v2/tag_request.go:78`](../../../vngcloud/services/loadbalancer/v2/tag_request.go#L78)). |
+| Duplicate keys in `WithTags` | In `UpdateTags.ToRequestBody`, map dedupe keeps the last value (matches LB). `CreateTags.ToRequestBody` keeps the duplicates in the order given (no dedup) — matches LB. |
+| `ListTags` on resource with no tags | API returns `[]`; `ToEntityListTags` returns an empty `*lsentity.ListTags`. No panic. |
+| Concurrent `UpdateTags` calls on same resource | Lost-update is possible (PUT after GET race) — same limitation as LB's `UpdateTags`. Not addressed; documented as a known limitation. |
+| `CreateSystemTags` legacy call path | Untouched. Continues to call `POST /<projectId>/tags` via `ServerServiceInternalV1`. |
+
+## Out of scope
+
+- Refactoring LB tag code into a shared helper.
+- Generic `TagService` consolidating all resource types.
+- Unit tests with HTTP mocking.
+- `DeleteTags` method (no DELETE endpoint exists at `/tag/resource/`).
+- Migrating existing `CreateSystemTags` callers to the new method.

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -438,3 +438,16 @@ func TestCreateServerTagsSuccess(t *ltesting.T) {
 	t.Log("Result: ", sdkErr)
 	t.Log("PASS")
 }
+
+func TestUpdateServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := lscomputeSvcV2.NewUpdateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").
+		WithTags("env", "prod")
+	sdkErr := vngcloud.VServerGateway().V2().ComputeService().UpdateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -409,3 +409,19 @@ func TestCreateSystemTags(t *ltesting.T) {
 	t.Log("Result: ", sdkerr)
 	t.Logf("Result: %v", response)
 }
+
+func TestListServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := lscomputeSvcV2.NewListTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f")
+	tags, sdkErr := vngcloud.VServerGateway().V2().ComputeService().ListTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if tags == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", tags)
+	t.Log("PASS")
+}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -425,3 +425,16 @@ func TestListServerTagsSuccess(t *ltesting.T) {
 	t.Log("Result: ", tags)
 	t.Log("PASS")
 }
+
+func TestCreateServerTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := lscomputeSvcV2.NewCreateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").
+		WithTags("env", "dev")
+	sdkErr := vngcloud.VServerGateway().V2().ComputeService().CreateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}

--- a/test/volume_test.go
+++ b/test/volume_test.go
@@ -235,3 +235,16 @@ func TestListVolumeTagsSuccess(t *ltesting.T) {
 	t.Log("Result: ", tags)
 	t.Log("PASS")
 }
+
+func TestCreateVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := v2.NewCreateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").
+		WithTags("env", "dev")
+	sdkErr := vngcloud.VServerGateway().V2().VolumeService().CreateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}

--- a/test/volume_test.go
+++ b/test/volume_test.go
@@ -219,3 +219,19 @@ func TestMigrateBlockVolume(t *ltesting.T) {
 	t.Log("Error: ", sdkerr)
 	t.Log("PASS")
 }
+
+func TestListVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := v2.NewListTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	tags, sdkErr := vngcloud.VServerGateway().V2().VolumeService().ListTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if tags == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", tags)
+	t.Log("PASS")
+}

--- a/test/volume_test.go
+++ b/test/volume_test.go
@@ -248,3 +248,16 @@ func TestCreateVolumeTagsSuccess(t *ltesting.T) {
 	t.Log("Result: ", sdkErr)
 	t.Log("PASS")
 }
+
+func TestUpdateVolumeTagsSuccess(t *ltesting.T) {
+	vngcloud := validSdkConfig()
+	opt := v2.NewUpdateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").
+		WithTags("env", "prod")
+	sdkErr := vngcloud.VServerGateway().V2().VolumeService().UpdateTags(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
+	}
+
+	t.Log("Result: ", sdkErr)
+	t.Log("PASS")
+}

--- a/vngcloud/services/compute/icompute.go
+++ b/vngcloud/services/compute/icompute.go
@@ -19,4 +19,5 @@ type IComputeServiceV2 interface {
 	DeleteServerGroupById(popts lscomputeSvcV2.IDeleteServerGroupByIdRequest) lserr.IError
 	ListServerGroups(popts lscomputeSvcV2.IListServerGroupsRequest) (*lsentity.ListServerGroups, lserr.IError)
 	CreateServerGroup(popts lscomputeSvcV2.ICreateServerGroupRequest) (*lsentity.ServerGroup, lserr.IError)
+	ListTags(popts lscomputeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
 }

--- a/vngcloud/services/compute/icompute.go
+++ b/vngcloud/services/compute/icompute.go
@@ -20,4 +20,5 @@ type IComputeServiceV2 interface {
 	ListServerGroups(popts lscomputeSvcV2.IListServerGroupsRequest) (*lsentity.ListServerGroups, lserr.IError)
 	CreateServerGroup(popts lscomputeSvcV2.ICreateServerGroupRequest) (*lsentity.ServerGroup, lserr.IError)
 	ListTags(popts lscomputeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
+	CreateTags(popts lscomputeSvcV2.ICreateTagsRequest) lserr.IError
 }

--- a/vngcloud/services/compute/icompute.go
+++ b/vngcloud/services/compute/icompute.go
@@ -21,4 +21,5 @@ type IComputeServiceV2 interface {
 	CreateServerGroup(popts lscomputeSvcV2.ICreateServerGroupRequest) (*lsentity.ServerGroup, lserr.IError)
 	ListTags(popts lscomputeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
 	CreateTags(popts lscomputeSvcV2.ICreateTagsRequest) lserr.IError
+	UpdateTags(popts lscomputeSvcV2.IUpdateTagsRequest) lserr.IError
 }

--- a/vngcloud/services/compute/v2/irequest.go
+++ b/vngcloud/services/compute/v2/irequest.go
@@ -1,5 +1,9 @@
 package v2
 
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+
 type ICreateServerRequest interface {
 	ToRequestBody() interface{}
 	WithRootDiskEncryptionType(pencryptionVolume DataDiskEncryptionType) ICreateServerRequest
@@ -113,4 +117,13 @@ type ICreateTagsRequest interface {
 	ParseUserAgent() string
 	WithTags(ptags ...string) ICreateTagsRequest
 	AddUserAgent(pagent ...string) ICreateTagsRequest
+}
+
+type IUpdateTagsRequest interface {
+	GetServerId() string
+	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) IUpdateTagsRequest
+	ToMap() map[string]interface{}
+	AddUserAgent(pagent ...string) IUpdateTagsRequest
 }

--- a/vngcloud/services/compute/v2/irequest.go
+++ b/vngcloud/services/compute/v2/irequest.go
@@ -106,3 +106,11 @@ type IListTagsRequest interface {
 	ParseUserAgent() string
 	AddUserAgent(pagent ...string) IListTagsRequest
 }
+
+type ICreateTagsRequest interface {
+	GetServerId() string
+	ToRequestBody() interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) ICreateTagsRequest
+	AddUserAgent(pagent ...string) ICreateTagsRequest
+}

--- a/vngcloud/services/compute/v2/irequest.go
+++ b/vngcloud/services/compute/v2/irequest.go
@@ -100,3 +100,9 @@ type ICreateServerGroupRequest interface {
 	ToRequestBody() interface{}
 	ToMap() map[string]interface{}
 }
+
+type IListTagsRequest interface {
+	GetServerId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListTagsRequest
+}

--- a/vngcloud/services/compute/v2/tag.go
+++ b/vngcloud/services/compute/v2/tag.go
@@ -22,3 +22,19 @@ func (s *ComputeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags,
 
 	return resp.ToEntityListTags(), nil
 }
+
+func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
+	url := createTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody()).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return nil
+}

--- a/vngcloud/services/compute/v2/tag.go
+++ b/vngcloud/services/compute/v2/tag.go
@@ -38,3 +38,33 @@ func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
 
 	return nil
 }
+
+func (s *ComputeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetServerId()))
+	if sdkErr != nil {
+		return sdkErr
+	}
+
+	// Do not update system tags
+	tags := new(lsentity.ListTags)
+	for _, tag := range tmpTags.Items {
+		if !tag.SystemTag {
+			tags.Items = append(tags.Items, tag)
+		}
+	}
+
+	url := updateTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody(tags)).
+		WithJsonError(errResp)
+
+	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp,
+			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
+	}
+
+	return nil
+}

--- a/vngcloud/services/compute/v2/tag.go
+++ b/vngcloud/services/compute/v2/tag.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+func (s *ComputeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, lserr.IError) {
+	url := listTagsUrl(s.VServerClient, popts)
+	resp := new(ListTagsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return resp.ToEntityListTags(), nil
+}

--- a/vngcloud/services/compute/v2/tag_request.go
+++ b/vngcloud/services/compute/v2/tag_request.go
@@ -1,0 +1,25 @@
+package v2
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+const (
+	serverResourceType = "SERVER"
+)
+
+func NewListTagsRequest(pserverId string) IListTagsRequest {
+	o := new(ListTagsRequest)
+	o.ServerId = pserverId
+	return o
+}
+
+func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+type ListTagsRequest struct {
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}

--- a/vngcloud/services/compute/v2/tag_request.go
+++ b/vngcloud/services/compute/v2/tag_request.go
@@ -23,3 +23,41 @@ type ListTagsRequest struct {
 	lscommon.UserAgent
 	lscommon.ServerCommon
 }
+
+func NewCreateTagsRequest(pserverId string) ICreateTagsRequest {
+	opts := new(CreateTagsRequest)
+	opts.ServerId = pserverId
+	opts.ResourceID = pserverId
+	opts.ResourceType = serverResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type CreateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *CreateTagsRequest) ToRequestBody() interface{} {
+	return s
+}
+
+func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+	return s
+}

--- a/vngcloud/services/compute/v2/tag_request.go
+++ b/vngcloud/services/compute/v2/tag_request.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
 	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
 )
 
@@ -60,4 +61,69 @@ func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
 		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
 	}
 	return s
+}
+
+func NewUpdateTagsRequest(pserverId string) IUpdateTagsRequest {
+	opts := new(UpdateTagsRequest)
+	opts.ServerId = pserverId
+	opts.ResourceID = pserverId
+	opts.ResourceType = serverResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type UpdateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
+	st := map[string]lscommon.Tag{}
+	for _, tag := range plstTags.Items {
+		st[tag.Key] = lscommon.Tag{
+			IsEdited: false,
+			Key:      tag.Key,
+			Value:    tag.Value,
+		}
+	}
+
+	for _, tag := range s.TagRequestList {
+		st[tag.Key] = tag
+	}
+
+	s.TagRequestList = make([]lscommon.Tag, 0)
+	for _, tag := range st {
+		s.TagRequestList = append(s.TagRequestList, tag)
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) WithTags(ptags ...string) IUpdateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) ToMap() map[string]interface{} {
+	res := make(map[string]interface{})
+	for _, tag := range s.TagRequestList {
+		res[tag.Key] = tag.Value
+	}
+	return res
 }

--- a/vngcloud/services/compute/v2/tag_response.go
+++ b/vngcloud/services/compute/v2/tag_response.go
@@ -1,0 +1,33 @@
+package v2
+
+import lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+
+type ListTagResponse struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	CreatedAt string `json:"createdAt"`
+	SystemTag bool   `json:"systemTag,omitempty"`
+}
+
+type ListTagsResponse []ListTagResponse
+
+func (s ListTagResponse) ToEntityTag() *lsentity.Tag {
+	return &lsentity.Tag{
+		Key:       s.Key,
+		Value:     s.Value,
+		SystemTag: s.SystemTag,
+	}
+}
+
+func (s *ListTagsResponse) ToEntityListTags() *lsentity.ListTags {
+	result := new(lsentity.ListTags)
+	if s == nil {
+		return result
+	}
+
+	for _, item := range *s {
+		result.Add(item.ToEntityTag())
+	}
+
+	return result
+}

--- a/vngcloud/services/compute/v2/url.go
+++ b/vngcloud/services/compute/v2/url.go
@@ -103,3 +103,9 @@ func createServerGroupUrl(psc lsclient.IServiceClient, _ ICreateServerGroupReque
 		"serverGroups",
 	)
 }
+
+func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}

--- a/vngcloud/services/compute/v2/url.go
+++ b/vngcloud/services/compute/v2/url.go
@@ -115,3 +115,9 @@ func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string
 		psc.GetProjectId(),
 		"tag", "resource", popts.GetServerId())
 }
+
+func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}

--- a/vngcloud/services/compute/v2/url.go
+++ b/vngcloud/services/compute/v2/url.go
@@ -109,3 +109,9 @@ func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
 		psc.GetProjectId(),
 		"tag", "resource", popts.GetServerId())
 }
+
+func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetServerId())
+}

--- a/vngcloud/services/volume/ivolume.go
+++ b/vngcloud/services/volume/ivolume.go
@@ -17,6 +17,7 @@ type IVolumeServiceV2 interface {
 	MigrateBlockVolumeById(popts lsvolumeSvcV2.IMigrateBlockVolumeByIdRequest) lserr.IError
 	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
 	CreateTags(popts lsvolumeSvcV2.ICreateTagsRequest) lserr.IError
+	UpdateTags(popts lsvolumeSvcV2.IUpdateTagsRequest) lserr.IError
 
 	// Snapshot
 	ListSnapshotsByBlockVolumeId(popts lsvolumeSvcV2.IListSnapshotsByBlockVolumeIdRequest) (*lsentity.ListSnapshots, lserr.IError)

--- a/vngcloud/services/volume/ivolume.go
+++ b/vngcloud/services/volume/ivolume.go
@@ -15,6 +15,7 @@ type IVolumeServiceV2 interface {
 	ResizeBlockVolumeById(popts lsvolumeSvcV2.IResizeBlockVolumeByIdRequest) (*lsentity.Volume, lserr.IError)
 	GetUnderBlockVolumeId(popts lsvolumeSvcV2.IGetUnderBlockVolumeIdRequest) (*lsentity.Volume, lserr.IError)
 	MigrateBlockVolumeById(popts lsvolumeSvcV2.IMigrateBlockVolumeByIdRequest) lserr.IError
+	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
 
 	// Snapshot
 	ListSnapshotsByBlockVolumeId(popts lsvolumeSvcV2.IListSnapshotsByBlockVolumeIdRequest) (*lsentity.ListSnapshots, lserr.IError)

--- a/vngcloud/services/volume/ivolume.go
+++ b/vngcloud/services/volume/ivolume.go
@@ -16,6 +16,7 @@ type IVolumeServiceV2 interface {
 	GetUnderBlockVolumeId(popts lsvolumeSvcV2.IGetUnderBlockVolumeIdRequest) (*lsentity.Volume, lserr.IError)
 	MigrateBlockVolumeById(popts lsvolumeSvcV2.IMigrateBlockVolumeByIdRequest) lserr.IError
 	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
+	CreateTags(popts lsvolumeSvcV2.ICreateTagsRequest) lserr.IError
 
 	// Snapshot
 	ListSnapshotsByBlockVolumeId(popts lsvolumeSvcV2.IListSnapshotsByBlockVolumeIdRequest) (*lsentity.ListSnapshots, lserr.IError)

--- a/vngcloud/services/volume/v2/irequest.go
+++ b/vngcloud/services/volume/v2/irequest.go
@@ -1,5 +1,9 @@
 package v2
 
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+
 type ICreateBlockVolumeRequest interface {
 	ToRequestBody() interface{}
 	ToMap() map[string]interface{}
@@ -87,4 +91,13 @@ type ICreateTagsRequest interface {
 	ParseUserAgent() string
 	WithTags(ptags ...string) ICreateTagsRequest
 	AddUserAgent(pagent ...string) ICreateTagsRequest
+}
+
+type IUpdateTagsRequest interface {
+	GetBlockVolumeId() string
+	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) IUpdateTagsRequest
+	ToMap() map[string]interface{}
+	AddUserAgent(pagent ...string) IUpdateTagsRequest
 }

--- a/vngcloud/services/volume/v2/irequest.go
+++ b/vngcloud/services/volume/v2/irequest.go
@@ -74,3 +74,9 @@ type IMigrateBlockVolumeByIdRequest interface {
 	WithConfirm(pconfirm bool) IMigrateBlockVolumeByIdRequest
 	IsConfirm() bool
 }
+
+type IListTagsRequest interface {
+	GetBlockVolumeId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListTagsRequest
+}

--- a/vngcloud/services/volume/v2/irequest.go
+++ b/vngcloud/services/volume/v2/irequest.go
@@ -80,3 +80,11 @@ type IListTagsRequest interface {
 	ParseUserAgent() string
 	AddUserAgent(pagent ...string) IListTagsRequest
 }
+
+type ICreateTagsRequest interface {
+	GetBlockVolumeId() string
+	ToRequestBody() interface{}
+	ParseUserAgent() string
+	WithTags(ptags ...string) ICreateTagsRequest
+	AddUserAgent(pagent ...string) ICreateTagsRequest
+}

--- a/vngcloud/services/volume/v2/tag.go
+++ b/vngcloud/services/volume/v2/tag.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+func (s *VolumeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, lserr.IError) {
+	url := listTagsUrl(s.VServerClient, popts)
+	resp := new(ListTagsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return resp.ToEntityListTags(), nil
+}

--- a/vngcloud/services/volume/v2/tag.go
+++ b/vngcloud/services/volume/v2/tag.go
@@ -22,3 +22,19 @@ func (s *VolumeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, 
 
 	return resp.ToEntityListTags(), nil
 }
+
+func (s *VolumeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
+	url := createTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody()).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	return nil
+}

--- a/vngcloud/services/volume/v2/tag.go
+++ b/vngcloud/services/volume/v2/tag.go
@@ -38,3 +38,33 @@ func (s *VolumeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
 
 	return nil
 }
+
+func (s *VolumeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetBlockVolumeId()))
+	if sdkErr != nil {
+		return sdkErr
+	}
+
+	// Do not update system tags
+	tags := new(lsentity.ListTags)
+	for _, tag := range tmpTags.Items {
+		if !tag.SystemTag {
+			tags.Items = append(tags.Items, tag)
+		}
+	}
+
+	url := updateTagsUrl(s.VServerClient, popts)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonBody(popts.ToRequestBody(tags)).
+		WithJsonError(errResp)
+
+	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
+		return lserr.SdkErrorHandler(sdkErr, errResp,
+			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
+	}
+
+	return nil
+}

--- a/vngcloud/services/volume/v2/tag_request.go
+++ b/vngcloud/services/volume/v2/tag_request.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
 	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
 )
 
@@ -60,4 +61,69 @@ func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
 		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
 	}
 	return s
+}
+
+func NewUpdateTagsRequest(pvolumeId string) IUpdateTagsRequest {
+	opts := new(UpdateTagsRequest)
+	opts.BlockVolumeId = pvolumeId
+	opts.ResourceID = pvolumeId
+	opts.ResourceType = volumeResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type UpdateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}
+
+func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
+	st := map[string]lscommon.Tag{}
+	for _, tag := range plstTags.Items {
+		st[tag.Key] = lscommon.Tag{
+			IsEdited: false,
+			Key:      tag.Key,
+			Value:    tag.Value,
+		}
+	}
+
+	for _, tag := range s.TagRequestList {
+		st[tag.Key] = tag
+	}
+
+	s.TagRequestList = make([]lscommon.Tag, 0)
+	for _, tag := range st {
+		s.TagRequestList = append(s.TagRequestList, tag)
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) WithTags(ptags ...string) IUpdateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+
+	return s
+}
+
+func (s *UpdateTagsRequest) ToMap() map[string]interface{} {
+	res := make(map[string]interface{})
+	for _, tag := range s.TagRequestList {
+		res[tag.Key] = tag.Value
+	}
+	return res
 }

--- a/vngcloud/services/volume/v2/tag_request.go
+++ b/vngcloud/services/volume/v2/tag_request.go
@@ -23,3 +23,41 @@ type ListTagsRequest struct {
 	lscommon.UserAgent
 	lscommon.BlockVolumeCommon
 }
+
+func NewCreateTagsRequest(pvolumeId string) ICreateTagsRequest {
+	opts := new(CreateTagsRequest)
+	opts.BlockVolumeId = pvolumeId
+	opts.ResourceID = pvolumeId
+	opts.ResourceType = volumeResourceType
+	opts.TagRequestList = make([]lscommon.Tag, 0)
+	return opts
+}
+
+type CreateTagsRequest struct {
+	ResourceID     string         `json:"resourceId"`
+	ResourceType   string         `json:"resourceType"`
+	TagRequestList []lscommon.Tag `json:"tagRequestList"`
+
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}
+
+func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *CreateTagsRequest) ToRequestBody() interface{} {
+	return s
+}
+
+func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
+	if len(ptags)%2 != 0 {
+		ptags = append(ptags, "none")
+	}
+
+	for i := 0; i < len(ptags); i += 2 {
+		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
+	}
+	return s
+}

--- a/vngcloud/services/volume/v2/tag_request.go
+++ b/vngcloud/services/volume/v2/tag_request.go
@@ -1,0 +1,25 @@
+package v2
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+const (
+	volumeResourceType = "VOLUME"
+)
+
+func NewListTagsRequest(pvolumeId string) IListTagsRequest {
+	o := new(ListTagsRequest)
+	o.BlockVolumeId = pvolumeId
+	return o
+}
+
+func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+type ListTagsRequest struct {
+	lscommon.UserAgent
+	lscommon.BlockVolumeCommon
+}

--- a/vngcloud/services/volume/v2/tag_response.go
+++ b/vngcloud/services/volume/v2/tag_response.go
@@ -1,0 +1,33 @@
+package v2
+
+import lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+
+type ListTagResponse struct {
+	Key       string `json:"key"`
+	Value     string `json:"value"`
+	CreatedAt string `json:"createdAt"`
+	SystemTag bool   `json:"systemTag,omitempty"`
+}
+
+type ListTagsResponse []ListTagResponse
+
+func (s ListTagResponse) ToEntityTag() *lsentity.Tag {
+	return &lsentity.Tag{
+		Key:       s.Key,
+		Value:     s.Value,
+		SystemTag: s.SystemTag,
+	}
+}
+
+func (s *ListTagsResponse) ToEntityListTags() *lsentity.ListTags {
+	result := new(lsentity.ListTags)
+	if s == nil {
+		return result
+	}
+
+	for _, item := range *s {
+		result.Add(item.ToEntityTag())
+	}
+
+	return result
+}

--- a/vngcloud/services/volume/v2/url.go
+++ b/vngcloud/services/volume/v2/url.go
@@ -96,3 +96,9 @@ func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
 		psc.GetProjectId(),
 		"tag", "resource", popts.GetBlockVolumeId())
 }
+
+func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}

--- a/vngcloud/services/volume/v2/url.go
+++ b/vngcloud/services/volume/v2/url.go
@@ -102,3 +102,9 @@ func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string
 		psc.GetProjectId(),
 		"tag", "resource", popts.GetBlockVolumeId())
 }
+
+func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}

--- a/vngcloud/services/volume/v2/url.go
+++ b/vngcloud/services/volume/v2/url.go
@@ -90,3 +90,9 @@ func migrateBlockVolumeByIdUrl(psc lsclient.IServiceClient, popts IMigrateBlockV
 		"change-device-type",
 	)
 }
+
+func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"tag", "resource", popts.GetBlockVolumeId())
+}


### PR DESCRIPTION
## Summary

Add `ListTags` / `CreateTags` / `UpdateTags` to `ComputeServiceV2` (for Servers) and `VolumeServiceV2` (for Volumes), calling the `/v2/{projectId}/tag/resource/{resourceId}` endpoints from `vserver-api-spec.json`. Pattern mirrors the existing LoadBalancer tag implementation in `vngcloud/services/loadbalancer/v2/`.

- `ListTags` — `GET`, returns `*lsentity.ListTags` (both system + user tags)
- `CreateTags` — `PUT`, raw replace (caller fully owns the tag list)
- `UpdateTags` — `PUT` with internal `ListTags`-then-filter-then-merge to preserve system tags (recommended for user code)

Spec: [docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md](docs/superpowers/specs/2026-05-17-tag-resource-api-sdk-design.md)
Plan: [docs/superpowers/plans/2026-05-17-tag-resource-api-sdk.md](docs/superpowers/plans/2026-05-17-tag-resource-api-sdk.md)

## What's NOT in this PR

- Existing `ServerServiceInternalV1.CreateSystemTags` (legacy `POST /tags`) is untouched.
- LoadBalancer tag code is untouched.
- No `DeleteTags` (no DELETE endpoint exists at `/tag/resource/`).
- No new unit tests with HTTP mocks (SDK has no such infrastructure).

## Test Plan

- [x] \`go build ./...\` exits 0
- [x] \`go vet ./vngcloud/...\` exits 0
- [x] \`go build ./test/...\` exits 0 (compile-check TDD: integration tests reference new SDK symbols)
- [ ] Manually run integration tests against a live vserver project (requires real credentials + valid resource IDs in tests):
  - \`go test -v -run TestListServerTagsSuccess ./test/...\`
  - \`go test -v -run TestCreateServerTagsSuccess ./test/...\`
  - \`go test -v -run TestUpdateServerTagsSuccess ./test/...\`
  - \`go test -v -run TestListVolumeTagsSuccess ./test/...\`
  - \`go test -v -run TestCreateVolumeTagsSuccess ./test/...\`
  - \`go test -v -run TestUpdateVolumeTagsSuccess ./test/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)