### PR TITLE
feat: add ListBlockVolumesByServerId to VolumeServiceV2

### DIFF
--- a/docs/superpowers/plans/2026-05-18-list-block-volumes-by-server-id.md
+++ b/docs/superpowers/plans/2026-05-18-list-block-volumes-by-server-id.md
@@ -1,0 +1,220 @@
+# ListBlockVolumesByServerId Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `ListBlockVolumesByServerId(serverId)` method to `VolumeServiceV2`, calling `GET /v2/{projectId}/volumes/servers/{serverId}` and returning `*lsentity.ListVolumes`.
+
+**Architecture:** Append-only modifications to existing files in `vngcloud/services/volume/v2/`. Reuse the existing `BlockVolume` struct as the response array element. Mirror the patterns of `ListBlockVolumes` / `GetBlockVolumeById` already in the package. No new files.
+
+**Tech Stack:** Go 1.x, vngcloud-go-sdk client primitives (`lsclient.IServiceClient`, `lsentity.ListVolumes`, `lscommon.ServerCommon`).
+
+**Spec:** [docs/superpowers/specs/2026-05-18-list-block-volumes-by-server-id-design.md](../specs/2026-05-18-list-block-volumes-by-server-id-design.md)
+
+**Reference implementation:** [vngcloud/services/volume/v2/blockvolume.go:50-67 (`ListBlockVolumes`)](../../../vngcloud/services/volume/v2/blockvolume.go#L50-L67), [blockvolume_response.go:9-15, 67-74 (`ListBlockVolumesResponse`)](../../../vngcloud/services/volume/v2/blockvolume_response.go)
+
+---
+
+## Conventions
+
+- **TDD via compile-check:** SDK has no unit-test infrastructure; integration tests in `test/` need real credentials. "Failing test" gate = `go build ./test/...` returning non-zero because the integration test references symbols that don't exist yet. "Test passes" gate = `go build ./...`, `go vet ./vngcloud/...`, and `go build ./test/...` all exit 0.
+- **Running the integration test** is the developer's manual step after the SDK builds — requires real `vngcloud` credentials and a valid server ID. Not part of plan execution.
+- **Test fixture ID:** `ins-da59addd-6263-4544-b405-420a65ccfb1f` (same hardcoded ID used in `TestCreateSystemTags` at [test/server_test.go:399](../../../test/server_test.go#L399)).
+- **Commit message format:** `feat: <short summary>` to match project history.
+
+---
+
+## Task 1: `ListBlockVolumesByServerId`
+
+**Files:**
+- Modify: `vngcloud/services/volume/v2/blockvolume.go` (append service method)
+- Modify: `vngcloud/services/volume/v2/blockvolume_request.go` (append request struct + constructor)
+- Modify: `vngcloud/services/volume/v2/blockvolume_response.go` (append response struct + mapper)
+- Modify: `vngcloud/services/volume/v2/irequest.go` (append interface)
+- Modify: `vngcloud/services/volume/v2/url.go` (append URL builder)
+- Modify: `vngcloud/services/volume/ivolume.go` (1 line in `IVolumeServiceV2` block)
+- Test: `test/volume_test.go` (append integration test)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `test/volume_test.go`:
+
+```go
+func TestListBlockVolumesByServerIdSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := v2.NewListBlockVolumesByServerIdRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f")
+	volumes, sdkErr := vngcloud.VServerGateway().V2().VolumeService().ListBlockVolumesByServerId(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if volumes == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", volumes)
+	t.Log("PASS")
+}
+```
+
+- [ ] **Step 2: Verify the build fails**
+
+Run: `go build ./test/...`
+Expected: build error referencing `NewListBlockVolumesByServerIdRequest` or `ListBlockVolumesByServerId` not declared in `v2` package / on `IVolumeServiceV2`.
+
+- [ ] **Step 3: Add the request interface**
+
+Append to `vngcloud/services/volume/v2/irequest.go`:
+
+```go
+
+type IListBlockVolumesByServerIdRequest interface {
+	GetServerId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest
+	ToMap() map[string]interface{}
+}
+```
+
+- [ ] **Step 4: Add the request struct + constructor**
+
+Append to `vngcloud/services/volume/v2/blockvolume_request.go`:
+
+```go
+
+func NewListBlockVolumesByServerIdRequest(pserverId string) IListBlockVolumesByServerIdRequest {
+	opt := new(ListBlockVolumesByServerIdRequest)
+	opt.ServerId = pserverId
+	return opt
+}
+
+type ListBlockVolumesByServerIdRequest struct {
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *ListBlockVolumesByServerIdRequest) AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *ListBlockVolumesByServerIdRequest) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"serverId": s.ServerId,
+	}
+}
+```
+
+Note: `lscommon.UserAgent` and `lscommon.ServerCommon` are already used elsewhere in this file via embedded types; the existing import `lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"` covers it. If for some reason `lscommon` is not yet imported, add it.
+
+- [ ] **Step 5: Add the response struct + entity mapper**
+
+Append to `vngcloud/services/volume/v2/blockvolume_response.go`:
+
+```go
+
+type ListBlockVolumesByServerIdResponse struct {
+	Volumes []BlockVolume `json:"volumes"`
+}
+
+func (s *ListBlockVolumesByServerIdResponse) ToEntityListVolumes() *lsentity.ListVolumes {
+	lst := new(lsentity.ListVolumes)
+	for _, v := range s.Volumes {
+		lst.Items = append(lst.Items, v.toEntityVolume())
+	}
+	return lst
+}
+```
+
+- [ ] **Step 6: Add the URL builder**
+
+Append to `vngcloud/services/volume/v2/url.go`:
+
+```go
+
+func listBlockVolumesByServerIdUrl(psc lsclient.IServiceClient, popts IListBlockVolumesByServerIdRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"volumes", "servers", popts.GetServerId())
+}
+```
+
+- [ ] **Step 7: Add the service method**
+
+Append to `vngcloud/services/volume/v2/blockvolume.go`:
+
+```go
+
+func (s *VolumeServiceV2) ListBlockVolumesByServerId(popts IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError) {
+	url := listBlockVolumesByServerIdUrl(s.VServerClient, popts)
+	resp := new(ListBlockVolumesByServerIdResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"projectId", s.getProjectId(),
+				"serverId", popts.GetServerId())
+	}
+
+	return resp.ToEntityListVolumes(), nil
+}
+```
+
+- [ ] **Step 8: Register the method on the public interface**
+
+In `vngcloud/services/volume/ivolume.go`, add this line inside the `IVolumeServiceV2` interface block, immediately after `MigrateBlockVolumeById` (before the existing tag methods or the `// Snapshot` section comment):
+
+```go
+	ListBlockVolumesByServerId(popts lsvolumeSvcV2.IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError)
+```
+
+- [ ] **Step 9: Verify the build passes**
+
+Run: `go build ./...`
+Expected: exit 0, no errors.
+
+Run: `go vet ./vngcloud/...`
+Expected: exit 0, no warnings.
+
+Run: `go build ./test/...`
+Expected: exit 0 (test file compiles).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add vngcloud/services/volume/v2/blockvolume.go \
+        vngcloud/services/volume/v2/blockvolume_request.go \
+        vngcloud/services/volume/v2/blockvolume_response.go \
+        vngcloud/services/volume/v2/irequest.go \
+        vngcloud/services/volume/v2/url.go \
+        vngcloud/services/volume/ivolume.go \
+        test/volume_test.go
+git commit -m "feat: add ListBlockVolumesByServerId to VolumeServiceV2"
+```
+
+(Use `git -c commit.gpgsign=false commit ...` if signing is configured.)
+
+---
+
+## Final verification
+
+- [ ] **Run full build + vet one last time**
+
+Run: `go build ./...` → exit 0
+Run: `go vet ./vngcloud/...` → exit 0
+Run: `go build ./test/...` → exit 0
+
+- [ ] **Optional: run the integration test (requires real credentials and a valid server ID)**
+
+Replace the hardcoded server ID in the test with a real one and run:
+
+```
+go test -v -run TestListBlockVolumesByServerIdSuccess ./test/...
+```
+
+Expected: PASS, logged volume list. Failures here indicate live-environment issues, not code defects.

--- a/docs/superpowers/specs/2026-05-18-list-block-volumes-by-server-id-design.md
+++ b/docs/superpowers/specs/2026-05-18-list-block-volumes-by-server-id-design.md
@@ -1,0 +1,224 @@
+# Design — `ListBlockVolumesByServerId` for `VolumeServiceV2`
+
+**Date:** 2026-05-18
+**Status:** Approved for implementation planning
+**Author:** tytv2
+
+## Background
+
+`vserver-api-spec.json` declares the endpoint:
+
+| Verb | Path | Operation |
+|------|------|-----------|
+| `GET` | `/v2/{projectId}/volumes/servers/{serverId}` | `getVolumeByInstanceIdUsingGET` |
+
+The spec summary is **"Get volume by server id"** (singular), but the response schema `VolumeResponse` is actually an **envelope** carrying a `volumes` array:
+
+```json
+{
+  "errorCode": int,
+  "errorMsg": string,
+  "extra": object,
+  "success": bool,
+  "volumes": [Volume, ...]
+}
+```
+
+So the endpoint returns **all volumes attached to a server**, not one. The spec wording is misleading.
+
+The SDK currently has no method that calls this endpoint. `VolumeServiceV2` already has `ListBlockVolumes` (project-scoped list) and `GetBlockVolumeById` (single volume by volume ID), but no way to list a server's volumes.
+
+## Goal
+
+Add a single new method `ListBlockVolumesByServerId(serverId)` on `VolumeServiceV2` that calls this endpoint and returns `*lsentity.ListVolumes`.
+
+## Non-goals
+
+- Implementing the adjacent `/v2/{projectId}/volumes/servers/{serverId}/boot` ("Get boot volume by server id") endpoint — that's a separate scope.
+- Refactoring or reusing `ListBlockVolumesResponse` — its envelope shape (`page`/`pageSize`/`listData`) is different from this endpoint's `VolumeResponse` shape (`volumes`).
+- Parsing the envelope's `success`/`errorCode`/`errorMsg` fields — the SDK's HTTP/error layer already handles non-200s via `lserr.SdkErrorHandler`. Match existing pattern (`ListBlockVolumes`, `GetBlockVolumeById`) which ignores those fields on 200 responses.
+
+## Architecture
+
+### File layout
+
+Append-only modifications to existing files in `vngcloud/services/volume/v2/`:
+
+| File | Change |
+|------|--------|
+| `vngcloud/services/volume/v2/blockvolume.go` | append `ListBlockVolumesByServerId` service method |
+| `vngcloud/services/volume/v2/blockvolume_request.go` | append `ListBlockVolumesByServerIdRequest` struct + `NewListBlockVolumesByServerIdRequest` constructor |
+| `vngcloud/services/volume/v2/blockvolume_response.go` | append `ListBlockVolumesByServerIdResponse` struct + `ToEntityListVolumes` mapper |
+| `vngcloud/services/volume/v2/irequest.go` | append `IListBlockVolumesByServerIdRequest` interface |
+| `vngcloud/services/volume/v2/url.go` | append `listBlockVolumesByServerIdUrl` URL builder |
+| `vngcloud/services/volume/ivolume.go` | 1 line registering the method in `IVolumeServiceV2` |
+| `test/volume_test.go` | append `TestListBlockVolumesByServerIdSuccess` integration test |
+
+No new files created.
+
+### Files NOT modified
+
+- All other services (`compute/`, `loadbalancer/`, `server/`, `network/`, etc.) — untouched.
+- The `boot` variant endpoint — out of scope.
+
+## Public API
+
+```go
+vngcloud.VServerGateway().V2().VolumeService().ListBlockVolumesByServerId(
+    lsvolumeV2.NewListBlockVolumesByServerIdRequest(serverId))
+// returns (*lsentity.ListVolumes, lserr.IError)
+```
+
+## Component design
+
+### Request interface
+
+```go
+type IListBlockVolumesByServerIdRequest interface {
+    GetServerId() string
+    ParseUserAgent() string
+    AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest
+    ToMap() map[string]interface{}
+}
+```
+
+`ToMap()` is included to match the `WithParameters(popts.ToMap())` pattern used by `ListBlockVolumes` and other v2 methods for error attribution.
+
+### Request struct + constructor
+
+```go
+type ListBlockVolumesByServerIdRequest struct {
+    lscommon.UserAgent
+    lscommon.ServerCommon  // exposes GetServerId()
+}
+
+func NewListBlockVolumesByServerIdRequest(pserverId string) IListBlockVolumesByServerIdRequest {
+    opt := new(ListBlockVolumesByServerIdRequest)
+    opt.ServerId = pserverId
+    return opt
+}
+
+func (s *ListBlockVolumesByServerIdRequest) AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest {
+    s.UserAgent.AddUserAgent(pagent...)
+    return s
+}
+
+func (s *ListBlockVolumesByServerIdRequest) ToMap() map[string]interface{} {
+    return map[string]interface{}{
+        "serverId": s.ServerId,
+    }
+}
+```
+
+### Response
+
+The endpoint's response envelope differs from `ListBlockVolumesResponse` (which is page-based), so a new struct is required. The array element type is the existing `BlockVolume` — reused for consistency.
+
+```go
+type ListBlockVolumesByServerIdResponse struct {
+    Volumes []BlockVolume `json:"volumes"`
+}
+
+func (s *ListBlockVolumesByServerIdResponse) ToEntityListVolumes() *lsentity.ListVolumes {
+    lst := new(lsentity.ListVolumes)
+    for _, v := range s.Volumes {
+        lst.Items = append(lst.Items, v.toEntityVolume())
+    }
+    return lst
+}
+```
+
+The envelope's `errorCode`/`errorMsg`/`extra`/`success` fields are intentionally not parsed — non-2xx responses are handled by `lserr.SdkErrorHandler` via the `JsonError` registered on the request. This matches the pattern of `ListBlockVolumesResponse` and `GetBlockVolumeByIdResponse`.
+
+### URL builder
+
+```go
+func listBlockVolumesByServerIdUrl(psc lsclient.IServiceClient, popts IListBlockVolumesByServerIdRequest) string {
+    return psc.ServiceURL(
+        psc.GetProjectId(),
+        "volumes", "servers", popts.GetServerId())
+}
+```
+
+Produces `/v2/{projectId}/volumes/servers/{serverId}` (the `v2` prefix and host come from `psc.ServiceURL`, matching every other endpoint in this package).
+
+### Service method
+
+```go
+func (s *VolumeServiceV2) ListBlockVolumesByServerId(popts IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError) {
+    url := listBlockVolumesByServerIdUrl(s.VServerClient, popts)
+    resp := new(ListBlockVolumesByServerIdResponse)
+    errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+    req := lsclient.NewRequest().
+        WithHeader("User-Agent", popts.ParseUserAgent()).
+        WithOkCodes(200).
+        WithJsonResponse(resp).
+        WithJsonError(errResp)
+
+    if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+        return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+            WithKVparameters(
+                "projectId", s.getProjectId(),
+                "serverId", popts.GetServerId())
+    }
+    return resp.ToEntityListVolumes(), nil
+}
+```
+
+### Interface registration
+
+In `vngcloud/services/volume/ivolume.go`, add this line inside the `IVolumeServiceV2` interface block (after `MigrateBlockVolumeById`, before the tag methods or `// Snapshot` section):
+
+```go
+ListBlockVolumesByServerId(popts lsvolumeSvcV2.IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError)
+```
+
+## Testing
+
+Integration test matching existing SDK style (hits live API, requires credentials):
+
+```go
+func TestListBlockVolumesByServerIdSuccess(t *ltesting.T) {
+    vngcloud := validSuperSdkConfig()
+    opt := v2.NewListBlockVolumesByServerIdRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f")
+    volumes, sdkErr := vngcloud.VServerGateway().V2().VolumeService().ListBlockVolumesByServerId(opt)
+    if sdkErr != nil {
+        t.Fatalf("Expect nil but got %+v", sdkErr)
+    }
+    if volumes == nil {
+        t.Fatalf("Expect not nil but got nil")
+    }
+    t.Log("Result: ", volumes)
+    t.Log("PASS")
+}
+```
+
+The hardcoded server ID matches the convention in [test/server_test.go:399](../../../test/server_test.go#L399) (developer replaces with a valid ID at runtime).
+
+Build-time verification (TDD-via-compile gate as established in the prior tag-resource feature):
+- `go build ./...` must exit 0
+- `go vet ./vngcloud/...` must exit 0
+- `go build ./test/...` must exit 0
+
+No unit tests with HTTP mocks (SDK has no such infrastructure).
+
+## Error handling
+
+`lserr.NormalErrorType` with no extra error helpers, matching the pattern in `ListBlockVolumes` ([blockvolume.go:50-67](../../../vngcloud/services/volume/v2/blockvolume.go#L50-L67)). Attribution via `WithKVparameters("projectId", ..., "serverId", ...)` so error messages identify the offending server.
+
+If the API returns a 4xx/5xx with a structured error body, `lserr.SdkErrorHandler` parses it from `errResp`. No new `WithError*` helpers added unless implementation reveals a server-specific error code worth surfacing.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| Server has no attached volumes | API returns `{ "volumes": [] }`; `ToEntityListVolumes` returns `&lsentity.ListVolumes{}` with empty `Items`. No panic. |
+| Server does not exist | API returns 4xx; `SdkErrorHandler` surfaces it with `serverId` in error attribution. |
+| Response envelope's `success: false` on a 200 | Not parsed (out of scope). Same behavior as `ListBlockVolumes` today. |
+
+## Out of scope
+
+- `/v2/{projectId}/volumes/servers/{serverId}/boot` endpoint.
+- Pagination — this endpoint doesn't paginate.
+- Filtering / query params — endpoint has none.
+- Refactoring existing volume response types.

--- a/test/volume_test.go
+++ b/test/volume_test.go
@@ -261,3 +261,19 @@ func TestUpdateVolumeTagsSuccess(t *ltesting.T) {
 	t.Log("Result: ", sdkErr)
 	t.Log("PASS")
 }
+
+func TestListBlockVolumesByServerIdSuccess(t *ltesting.T) {
+	vngcloud := validSuperSdkConfig()
+	opt := v2.NewListBlockVolumesByServerIdRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f")
+	volumes, sdkErr := vngcloud.VServerGateway().V2().VolumeService().ListBlockVolumesByServerId(opt)
+	if sdkErr != nil {
+		t.Fatalf("Expect nil but got %+v", sdkErr)
+	}
+
+	if volumes == nil {
+		t.Fatalf("Expect not nil but got nil")
+	}
+
+	t.Log("Result: ", volumes)
+	t.Log("PASS")
+}

--- a/vngcloud/services/volume/ivolume.go
+++ b/vngcloud/services/volume/ivolume.go
@@ -15,6 +15,7 @@ type IVolumeServiceV2 interface {
 	ResizeBlockVolumeById(popts lsvolumeSvcV2.IResizeBlockVolumeByIdRequest) (*lsentity.Volume, lserr.IError)
 	GetUnderBlockVolumeId(popts lsvolumeSvcV2.IGetUnderBlockVolumeIdRequest) (*lsentity.Volume, lserr.IError)
 	MigrateBlockVolumeById(popts lsvolumeSvcV2.IMigrateBlockVolumeByIdRequest) lserr.IError
+	ListBlockVolumesByServerId(popts lsvolumeSvcV2.IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError)
 	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
 	CreateTags(popts lsvolumeSvcV2.ICreateTagsRequest) lserr.IError
 	UpdateTags(popts lsvolumeSvcV2.IUpdateTagsRequest) lserr.IError

--- a/vngcloud/services/volume/v2/blockvolume.go
+++ b/vngcloud/services/volume/v2/blockvolume.go
@@ -175,3 +175,23 @@ func (s *VolumeServiceV2) MigrateBlockVolumeById(popts IMigrateBlockVolumeByIdRe
 
 	return nil
 }
+
+func (s *VolumeServiceV2) ListBlockVolumesByServerId(popts IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError) {
+	url := listBlockVolumesByServerIdUrl(s.VServerClient, popts)
+	resp := new(ListBlockVolumesByServerIdResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VServerClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"projectId", s.getProjectId(),
+				"serverId", popts.GetServerId())
+	}
+
+	return resp.ToEntityListVolumes(), nil
+}

--- a/vngcloud/services/volume/v2/blockvolume_request.go
+++ b/vngcloud/services/volume/v2/blockvolume_request.go
@@ -342,3 +342,25 @@ func (s *MigrateBlockVolumeByIdRequest) WithConfirm(pconfirm bool) IMigrateBlock
 func (s *MigrateBlockVolumeByIdRequest) IsConfirm() bool {
 	return s.ConfirmMigrate
 }
+
+func NewListBlockVolumesByServerIdRequest(pserverId string) IListBlockVolumesByServerIdRequest {
+	opt := new(ListBlockVolumesByServerIdRequest)
+	opt.ServerId = pserverId
+	return opt
+}
+
+type ListBlockVolumesByServerIdRequest struct {
+	lscommon.UserAgent
+	lscommon.ServerCommon
+}
+
+func (s *ListBlockVolumesByServerIdRequest) AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest {
+	s.UserAgent.AddUserAgent(pagent...)
+	return s
+}
+
+func (s *ListBlockVolumesByServerIdRequest) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"serverId": s.ServerId,
+	}
+}

--- a/vngcloud/services/volume/v2/blockvolume_response.go
+++ b/vngcloud/services/volume/v2/blockvolume_response.go
@@ -99,3 +99,15 @@ func (s *GetUnderBlockVolumeIdResponse) ToEntityVolume() *lsentity.Volume {
 		UnderId: s.Uuid,
 	}
 }
+
+type ListBlockVolumesByServerIdResponse struct {
+	Volumes []BlockVolume `json:"volumes"`
+}
+
+func (s *ListBlockVolumesByServerIdResponse) ToEntityListVolumes() *lsentity.ListVolumes {
+	lst := new(lsentity.ListVolumes)
+	for _, v := range s.Volumes {
+		lst.Items = append(lst.Items, v.toEntityVolume())
+	}
+	return lst
+}

--- a/vngcloud/services/volume/v2/irequest.go
+++ b/vngcloud/services/volume/v2/irequest.go
@@ -101,3 +101,10 @@ type IUpdateTagsRequest interface {
 	ToMap() map[string]interface{}
 	AddUserAgent(pagent ...string) IUpdateTagsRequest
 }
+
+type IListBlockVolumesByServerIdRequest interface {
+	GetServerId() string
+	ParseUserAgent() string
+	AddUserAgent(pagent ...string) IListBlockVolumesByServerIdRequest
+	ToMap() map[string]interface{}
+}

--- a/vngcloud/services/volume/v2/url.go
+++ b/vngcloud/services/volume/v2/url.go
@@ -108,3 +108,9 @@ func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string
 		psc.GetProjectId(),
 		"tag", "resource", popts.GetBlockVolumeId())
 }
+
+func listBlockVolumesByServerIdUrl(psc lsclient.IServiceClient, popts IListBlockVolumesByServerIdRequest) string {
+	return psc.ServiceURL(
+		psc.GetProjectId(),
+		"volumes", "servers", popts.GetServerId())
+}


### PR DESCRIPTION
## Summary

Adds `VolumeServiceV2.ListBlockVolumesByServerId(serverId)` calling `GET /v2/{projectId}/volumes/servers/{serverId}` (operationId `getVolumeByInstanceIdUsingGET` in `vserver-api-spec.json`). Returns all volumes attached to a server as `*lsentity.ListVolumes`.

Note: the spec summary says "Get volume by server id" (singular), but the actual `VolumeResponse` schema wraps a `volumes` array — the method correctly returns the list, not a single volume. Method named `ListBlockVolumesByServerId` to reflect the real return shape.

Spec: [docs/superpowers/specs/2026-05-18-list-block-volumes-by-server-id-design.md](docs/superpowers/specs/2026-05-18-list-block-volumes-by-server-id-design.md)
Plan: [docs/superpowers/plans/2026-05-18-list-block-volumes-by-server-id.md](docs/superpowers/plans/2026-05-18-list-block-volumes-by-server-id.md)

## Changes

- New method on \`VolumeServiceV2\` and \`IVolumeServiceV2\` interface
- New request type \`ListBlockVolumesByServerIdRequest\` + constructor \`NewListBlockVolumesByServerIdRequest\`
- New response type \`ListBlockVolumesByServerIdResponse\` (reuses existing \`BlockVolume\` for items)
- New URL builder and integration test
- Append-only modifications to existing files; no new files

## Test Plan

- [x] \`go build ./...\` exits 0
- [x] \`go vet ./vngcloud/...\` exits 0
- [x] \`go build ./test/...\` exits 0
- [ ] Manually run integration test against live vserver (real credentials + valid server ID):
  \`go test -v -run TestListBlockVolumesByServerIdSuccess ./test/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)