### PR TITLE
refactor: simplify UpdateTags and remove CreateTags on Compute/Volume

### DIFF
--- a/test/server_test.go
+++ b/test/server_test.go
@@ -426,19 +426,6 @@ func TestListServerTagsSuccess(t *ltesting.T) {
 	t.Log("PASS")
 }
 
-func TestCreateServerTagsSuccess(t *ltesting.T) {
-	vngcloud := validSdkConfig()
-	opt := lscomputeSvcV2.NewCreateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").
-		WithTags("env", "dev")
-	sdkErr := vngcloud.VServerGateway().V2().ComputeService().CreateTags(opt)
-	if sdkErr != nil {
-		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
-	}
-
-	t.Log("Result: ", sdkErr)
-	t.Log("PASS")
-}
-
 func TestUpdateServerTagsSuccess(t *ltesting.T) {
 	vngcloud := validSdkConfig()
 	opt := lscomputeSvcV2.NewUpdateTagsRequest("ins-da59addd-6263-4544-b405-420a65ccfb1f").

--- a/test/volume_test.go
+++ b/test/volume_test.go
@@ -236,19 +236,6 @@ func TestListVolumeTagsSuccess(t *ltesting.T) {
 	t.Log("PASS")
 }
 
-func TestCreateVolumeTagsSuccess(t *ltesting.T) {
-	vngcloud := validSdkConfig()
-	opt := v2.NewCreateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").
-		WithTags("env", "dev")
-	sdkErr := vngcloud.VServerGateway().V2().VolumeService().CreateTags(opt)
-	if sdkErr != nil {
-		t.Fatalf("Expect nil but got %+v", sdkErr.GetMessage())
-	}
-
-	t.Log("Result: ", sdkErr)
-	t.Log("PASS")
-}
-
 func TestUpdateVolumeTagsSuccess(t *ltesting.T) {
 	vngcloud := validSdkConfig()
 	opt := v2.NewUpdateTagsRequest("vol-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").

--- a/vngcloud/services/compute/icompute.go
+++ b/vngcloud/services/compute/icompute.go
@@ -20,6 +20,5 @@ type IComputeServiceV2 interface {
 	ListServerGroups(popts lscomputeSvcV2.IListServerGroupsRequest) (*lsentity.ListServerGroups, lserr.IError)
 	CreateServerGroup(popts lscomputeSvcV2.ICreateServerGroupRequest) (*lsentity.ServerGroup, lserr.IError)
 	ListTags(popts lscomputeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
-	CreateTags(popts lscomputeSvcV2.ICreateTagsRequest) lserr.IError
 	UpdateTags(popts lscomputeSvcV2.IUpdateTagsRequest) lserr.IError
 }

--- a/vngcloud/services/compute/v2/irequest.go
+++ b/vngcloud/services/compute/v2/irequest.go
@@ -1,9 +1,5 @@
 package v2
 
-import (
-	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
-)
-
 type ICreateServerRequest interface {
 	ToRequestBody() interface{}
 	WithRootDiskEncryptionType(pencryptionVolume DataDiskEncryptionType) ICreateServerRequest
@@ -111,17 +107,9 @@ type IListTagsRequest interface {
 	AddUserAgent(pagent ...string) IListTagsRequest
 }
 
-type ICreateTagsRequest interface {
-	GetServerId() string
-	ToRequestBody() interface{}
-	ParseUserAgent() string
-	WithTags(ptags ...string) ICreateTagsRequest
-	AddUserAgent(pagent ...string) ICreateTagsRequest
-}
-
 type IUpdateTagsRequest interface {
 	GetServerId() string
-	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ToRequestBody() interface{}
 	ParseUserAgent() string
 	WithTags(ptags ...string) IUpdateTagsRequest
 	ToMap() map[string]interface{}

--- a/vngcloud/services/compute/v2/tag.go
+++ b/vngcloud/services/compute/v2/tag.go
@@ -23,8 +23,12 @@ func (s *ComputeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags,
 	return resp.ToEntityListTags(), nil
 }
 
-func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
-	url := createTagsUrl(s.VServerClient, popts)
+// UpdateTags upserts the given tag keys on the server: existing keys have
+// their values overwritten, new keys are created. Keys not in the request
+// list are left untouched (the vserver endpoint is upsert-by-key, not
+// replace-all).
+func (s *ComputeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	url := updateTagsUrl(s.VServerClient, popts)
 	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
 	req := lsclient.NewRequest().
 		WithHeader("User-Agent", popts.ParseUserAgent()).
@@ -33,35 +37,6 @@ func (s *ComputeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
 		WithJsonError(errResp)
 
 	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
-		return lserr.SdkErrorHandler(sdkErr, errResp)
-	}
-
-	return nil
-}
-
-func (s *ComputeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
-	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetServerId()))
-	if sdkErr != nil {
-		return sdkErr
-	}
-
-	// Do not update system tags
-	tags := new(lsentity.ListTags)
-	for _, tag := range tmpTags.Items {
-		if !tag.SystemTag {
-			tags.Items = append(tags.Items, tag)
-		}
-	}
-
-	url := updateTagsUrl(s.VServerClient, popts)
-	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
-	req := lsclient.NewRequest().
-		WithHeader("User-Agent", popts.ParseUserAgent()).
-		WithOkCodes(200).
-		WithJsonBody(popts.ToRequestBody(tags)).
-		WithJsonError(errResp)
-
-	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
 		return lserr.SdkErrorHandler(sdkErr, errResp,
 			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
 	}

--- a/vngcloud/services/compute/v2/tag_request.go
+++ b/vngcloud/services/compute/v2/tag_request.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
 	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
 )
 
@@ -23,44 +22,6 @@ func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
 type ListTagsRequest struct {
 	lscommon.UserAgent
 	lscommon.ServerCommon
-}
-
-func NewCreateTagsRequest(pserverId string) ICreateTagsRequest {
-	opts := new(CreateTagsRequest)
-	opts.ServerId = pserverId
-	opts.ResourceID = pserverId
-	opts.ResourceType = serverResourceType
-	opts.TagRequestList = make([]lscommon.Tag, 0)
-	return opts
-}
-
-type CreateTagsRequest struct {
-	ResourceID     string         `json:"resourceId"`
-	ResourceType   string         `json:"resourceType"`
-	TagRequestList []lscommon.Tag `json:"tagRequestList"`
-
-	lscommon.UserAgent
-	lscommon.ServerCommon
-}
-
-func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
-	s.UserAgent.AddUserAgent(pagent...)
-	return s
-}
-
-func (s *CreateTagsRequest) ToRequestBody() interface{} {
-	return s
-}
-
-func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
-	if len(ptags)%2 != 0 {
-		ptags = append(ptags, "none")
-	}
-
-	for i := 0; i < len(ptags); i += 2 {
-		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
-	}
-	return s
 }
 
 func NewUpdateTagsRequest(pserverId string) IUpdateTagsRequest {
@@ -86,25 +47,7 @@ func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
 	return s
 }
 
-func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
-	st := map[string]lscommon.Tag{}
-	for _, tag := range plstTags.Items {
-		st[tag.Key] = lscommon.Tag{
-			IsEdited: false,
-			Key:      tag.Key,
-			Value:    tag.Value,
-		}
-	}
-
-	for _, tag := range s.TagRequestList {
-		st[tag.Key] = tag
-	}
-
-	s.TagRequestList = make([]lscommon.Tag, 0)
-	for _, tag := range st {
-		s.TagRequestList = append(s.TagRequestList, tag)
-	}
-
+func (s *UpdateTagsRequest) ToRequestBody() interface{} {
 	return s
 }
 

--- a/vngcloud/services/compute/v2/url.go
+++ b/vngcloud/services/compute/v2/url.go
@@ -110,12 +110,6 @@ func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
 		"tag", "resource", popts.GetServerId())
 }
 
-func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
-	return psc.ServiceURL(
-		psc.GetProjectId(),
-		"tag", "resource", popts.GetServerId())
-}
-
 func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
 	return psc.ServiceURL(
 		psc.GetProjectId(),

--- a/vngcloud/services/volume/ivolume.go
+++ b/vngcloud/services/volume/ivolume.go
@@ -17,7 +17,6 @@ type IVolumeServiceV2 interface {
 	MigrateBlockVolumeById(popts lsvolumeSvcV2.IMigrateBlockVolumeByIdRequest) lserr.IError
 	ListBlockVolumesByServerId(popts lsvolumeSvcV2.IListBlockVolumesByServerIdRequest) (*lsentity.ListVolumes, lserr.IError)
 	ListTags(popts lsvolumeSvcV2.IListTagsRequest) (*lsentity.ListTags, lserr.IError)
-	CreateTags(popts lsvolumeSvcV2.ICreateTagsRequest) lserr.IError
 	UpdateTags(popts lsvolumeSvcV2.IUpdateTagsRequest) lserr.IError
 
 	// Snapshot

--- a/vngcloud/services/volume/v2/irequest.go
+++ b/vngcloud/services/volume/v2/irequest.go
@@ -1,9 +1,5 @@
 package v2
 
-import (
-	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
-)
-
 type ICreateBlockVolumeRequest interface {
 	ToRequestBody() interface{}
 	ToMap() map[string]interface{}
@@ -85,17 +81,9 @@ type IListTagsRequest interface {
 	AddUserAgent(pagent ...string) IListTagsRequest
 }
 
-type ICreateTagsRequest interface {
-	GetBlockVolumeId() string
-	ToRequestBody() interface{}
-	ParseUserAgent() string
-	WithTags(ptags ...string) ICreateTagsRequest
-	AddUserAgent(pagent ...string) ICreateTagsRequest
-}
-
 type IUpdateTagsRequest interface {
 	GetBlockVolumeId() string
-	ToRequestBody(plstTags *lsentity.ListTags) interface{}
+	ToRequestBody() interface{}
 	ParseUserAgent() string
 	WithTags(ptags ...string) IUpdateTagsRequest
 	ToMap() map[string]interface{}

--- a/vngcloud/services/volume/v2/tag.go
+++ b/vngcloud/services/volume/v2/tag.go
@@ -23,8 +23,12 @@ func (s *VolumeServiceV2) ListTags(popts IListTagsRequest) (*lsentity.ListTags, 
 	return resp.ToEntityListTags(), nil
 }
 
-func (s *VolumeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
-	url := createTagsUrl(s.VServerClient, popts)
+// UpdateTags upserts the given tag keys on the volume: existing keys have
+// their values overwritten, new keys are created. Keys not in the request
+// list are left untouched (the vserver endpoint is upsert-by-key, not
+// replace-all).
+func (s *VolumeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
+	url := updateTagsUrl(s.VServerClient, popts)
 	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
 	req := lsclient.NewRequest().
 		WithHeader("User-Agent", popts.ParseUserAgent()).
@@ -33,35 +37,6 @@ func (s *VolumeServiceV2) CreateTags(popts ICreateTagsRequest) lserr.IError {
 		WithJsonError(errResp)
 
 	if _, sdkErr := s.VServerClient.Put(url, req); sdkErr != nil {
-		return lserr.SdkErrorHandler(sdkErr, errResp)
-	}
-
-	return nil
-}
-
-func (s *VolumeServiceV2) UpdateTags(popts IUpdateTagsRequest) lserr.IError {
-	tmpTags, sdkErr := s.ListTags(NewListTagsRequest(popts.GetBlockVolumeId()))
-	if sdkErr != nil {
-		return sdkErr
-	}
-
-	// Do not update system tags
-	tags := new(lsentity.ListTags)
-	for _, tag := range tmpTags.Items {
-		if !tag.SystemTag {
-			tags.Items = append(tags.Items, tag)
-		}
-	}
-
-	url := updateTagsUrl(s.VServerClient, popts)
-	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
-	req := lsclient.NewRequest().
-		WithHeader("User-Agent", popts.ParseUserAgent()).
-		WithOkCodes(200).
-		WithJsonBody(popts.ToRequestBody(tags)).
-		WithJsonError(errResp)
-
-	if _, sdkErr = s.VServerClient.Put(url, req); sdkErr != nil {
 		return lserr.SdkErrorHandler(sdkErr, errResp,
 			lserr.WithErrorTagKeyInvalid(errResp)).WithParameters(popts.ToMap())
 	}

--- a/vngcloud/services/volume/v2/tag_request.go
+++ b/vngcloud/services/volume/v2/tag_request.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
 	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
 )
 
@@ -23,44 +22,6 @@ func (s *ListTagsRequest) AddUserAgent(pagent ...string) IListTagsRequest {
 type ListTagsRequest struct {
 	lscommon.UserAgent
 	lscommon.BlockVolumeCommon
-}
-
-func NewCreateTagsRequest(pvolumeId string) ICreateTagsRequest {
-	opts := new(CreateTagsRequest)
-	opts.BlockVolumeId = pvolumeId
-	opts.ResourceID = pvolumeId
-	opts.ResourceType = volumeResourceType
-	opts.TagRequestList = make([]lscommon.Tag, 0)
-	return opts
-}
-
-type CreateTagsRequest struct {
-	ResourceID     string         `json:"resourceId"`
-	ResourceType   string         `json:"resourceType"`
-	TagRequestList []lscommon.Tag `json:"tagRequestList"`
-
-	lscommon.UserAgent
-	lscommon.BlockVolumeCommon
-}
-
-func (s *CreateTagsRequest) AddUserAgent(pagent ...string) ICreateTagsRequest {
-	s.UserAgent.AddUserAgent(pagent...)
-	return s
-}
-
-func (s *CreateTagsRequest) ToRequestBody() interface{} {
-	return s
-}
-
-func (s *CreateTagsRequest) WithTags(ptags ...string) ICreateTagsRequest {
-	if len(ptags)%2 != 0 {
-		ptags = append(ptags, "none")
-	}
-
-	for i := 0; i < len(ptags); i += 2 {
-		s.TagRequestList = append(s.TagRequestList, lscommon.Tag{Key: ptags[i], Value: ptags[i+1]})
-	}
-	return s
 }
 
 func NewUpdateTagsRequest(pvolumeId string) IUpdateTagsRequest {
@@ -86,25 +47,7 @@ func (s *UpdateTagsRequest) AddUserAgent(pagent ...string) IUpdateTagsRequest {
 	return s
 }
 
-func (s *UpdateTagsRequest) ToRequestBody(plstTags *lsentity.ListTags) interface{} {
-	st := map[string]lscommon.Tag{}
-	for _, tag := range plstTags.Items {
-		st[tag.Key] = lscommon.Tag{
-			IsEdited: false,
-			Key:      tag.Key,
-			Value:    tag.Value,
-		}
-	}
-
-	for _, tag := range s.TagRequestList {
-		st[tag.Key] = tag
-	}
-
-	s.TagRequestList = make([]lscommon.Tag, 0)
-	for _, tag := range st {
-		s.TagRequestList = append(s.TagRequestList, tag)
-	}
-
+func (s *UpdateTagsRequest) ToRequestBody() interface{} {
 	return s
 }
 

--- a/vngcloud/services/volume/v2/url.go
+++ b/vngcloud/services/volume/v2/url.go
@@ -97,12 +97,6 @@ func listTagsUrl(psc lsclient.IServiceClient, popts IListTagsRequest) string {
 		"tag", "resource", popts.GetBlockVolumeId())
 }
 
-func createTagsUrl(psc lsclient.IServiceClient, popts ICreateTagsRequest) string {
-	return psc.ServiceURL(
-		psc.GetProjectId(),
-		"tag", "resource", popts.GetBlockVolumeId())
-}
-
 func updateTagsUrl(psc lsclient.IServiceClient, popts IUpdateTagsRequest) string {
 	return psc.ServiceURL(
 		psc.GetProjectId(),


### PR DESCRIPTION
## Summary

Aligns the SDK with the actual vserver tag-resource API semantics (confirmed with vserver team): \`PUT /v2/{projectId}/tag/resource/{resourceId}\` performs **upsert-by-key** on \`tagRequestList\`, not replace-all.

- Keys in the request → values updated (or new keys created).
- Keys absent from the request → left untouched.
- The body's \`tags\` field is unused; only \`tagRequestList\` matters.

### Changes

- **Drop \`CreateTags\`** on \`ComputeServiceV2\` and \`VolumeServiceV2\` (and their request types/interfaces/URL builders).
- **Simplify \`UpdateTags\`** on both services to a single direct \`PUT\` — no more \`ListTags\` + filter-system-tags + dedup-merge prelude. That defensive merge was guarding against a replace-all semantic that doesn't apply.
- **Drop the \`ToRequestBody(plstTags)\` parameter** on \`IUpdateTagsRequest\` (no more pre-fetched list to merge in).
- **Remove the now-redundant tests** \`TestCreateServerTagsSuccess\` and \`TestCreateVolumeTagsSuccess\`; \`TestUpdateServerTagsSuccess\` and \`TestUpdateVolumeTagsSuccess\` remain.

### Not in this PR

- \`LoadBalancerServiceV2.UpdateTags\` uses the same merge pattern but is left untouched (out of scope; separate PR if desired).
- No changes to entity types or the response shape.

### Breaking changes

- \`ComputeServiceV2.CreateTags\` and \`VolumeServiceV2.CreateTags\` are removed. Callers should use \`UpdateTags\` instead — same effective behavior (and now correctly named for the upsert semantic).
- \`ICreateTagsRequest\` / \`NewCreateTagsRequest\` / \`CreateTagsRequest\` removed from both packages.
- \`IUpdateTagsRequest.ToRequestBody\` signature changed from \`ToRequestBody(*lsentity.ListTags) interface{}\` to \`ToRequestBody() interface{}\`.

Net: **+16 / −244 lines**.

## Test Plan

- [x] \`go build ./...\` exits 0
- [x] \`go vet ./vngcloud/...\` exits 0
- [x] \`go build ./test/...\` exits 0
- [ ] Manual integration tests with real credentials:
  - \`go test -v -run TestUpdateServerTagsSuccess ./test/...\`
  - \`go test -v -run TestUpdateVolumeTagsSuccess ./test/...\`
  - Verify system tags (e.g. \`vng.billing.*\`) on the target resource are **not** wiped after an UpdateTags call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)