### PR TITLE
feat: add vDB Kafka service for VKS control-plane logging

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,7 @@ type (
 		vnetworkGateway lsgateway.IVNetworkGateway
 		glbGateway      lsgateway.IGLBGateway
 		vdnsGateway     lsgateway.IVDnsGateway
+		vdbKafkaGateway lsgateway.IVDBKafkaGateway
 	}
 )
 
@@ -199,6 +200,10 @@ func (s *client) Configure(psdkCfg ISdkConfigure) IClient {
 		s.vdnsGateway = lsgateway.NewVDnsGateway(psdkCfg.GetVDnsEndpoint(), s.projectId, s.httpClient)
 	}
 
+	if s.vdbKafkaGateway == nil && psdkCfg.GetVdbKafkaEndpoint() != "" {
+		s.vdbKafkaGateway = lsgateway.NewVDBKafkaGateway(psdkCfg.GetVdbKafkaEndpoint(), s.userId, s.httpClient)
+	}
+
 	s.httpClient.WithReauthFunc(lsclient.IamOauth2, s.usingIamOauth2AsAuthOption(psdkCfg))
 	s.userAgent = psdkCfg.GetUserAgent()
 
@@ -231,6 +236,10 @@ func (s *client) GLBGateway() lsgateway.IGLBGateway {
 
 func (s *client) VDnsGateway() lsgateway.IVDnsGateway {
 	return s.vdnsGateway
+}
+
+func (s *client) VDBKafkaGateway() lsgateway.IVDBKafkaGateway {
+	return s.vdbKafkaGateway
 }
 
 func (s *client) usingIamOauth2AsAuthOption(pauthConfig ISdkConfigure) func() (lsclient.ISdkAuthentication, lserr.IError) {

--- a/client/client.go
+++ b/client/client.go
@@ -24,14 +24,15 @@ type (
 		userAgent  string
 		authOpt    lsclient.AuthOpts
 
-		iamGateway      lsgateway.IIamGateway
-		vserverGateway  lsgateway.IVServerGateway
-		vlbGateway      lsgateway.IVLBGateway
-		vbackupGateway  lsgateway.IVBackUpGateway
-		vnetworkGateway lsgateway.IVNetworkGateway
-		glbGateway      lsgateway.IGLBGateway
-		vdnsGateway     lsgateway.IVDnsGateway
-		vdbKafkaGateway lsgateway.IVDBKafkaGateway
+		iamGateway           lsgateway.IIamGateway
+		vserverGateway       lsgateway.IVServerGateway
+		vlbGateway           lsgateway.IVLBGateway
+		vbackupGateway       lsgateway.IVBackUpGateway
+		vnetworkGateway      lsgateway.IVNetworkGateway
+		glbGateway           lsgateway.IGLBGateway
+		vdnsGateway          lsgateway.IVDnsGateway
+		vdbKafkaGateway      lsgateway.IVDBKafkaGateway
+		vdbOpenSearchGateway lsgateway.IVDBOpenSearchGateway
 	}
 )
 
@@ -204,6 +205,10 @@ func (s *client) Configure(psdkCfg ISdkConfigure) IClient {
 		s.vdbKafkaGateway = lsgateway.NewVDBKafkaGateway(psdkCfg.GetVdbKafkaEndpoint(), s.userId, s.httpClient)
 	}
 
+	if s.vdbOpenSearchGateway == nil && psdkCfg.GetVdbOpenSearchEndpoint() != "" {
+		s.vdbOpenSearchGateway = lsgateway.NewVDBOpenSearchGateway(psdkCfg.GetVdbOpenSearchEndpoint(), s.userId, s.projectId, s.httpClient)
+	}
+
 	s.httpClient.WithReauthFunc(lsclient.IamOauth2, s.usingIamOauth2AsAuthOption(psdkCfg))
 	s.userAgent = psdkCfg.GetUserAgent()
 
@@ -240,6 +245,10 @@ func (s *client) VDnsGateway() lsgateway.IVDnsGateway {
 
 func (s *client) VDBKafkaGateway() lsgateway.IVDBKafkaGateway {
 	return s.vdbKafkaGateway
+}
+
+func (s *client) VDBOpenSearchGateway() lsgateway.IVDBOpenSearchGateway {
+	return s.vdbOpenSearchGateway
 }
 
 func (s *client) usingIamOauth2AsAuthOption(pauthConfig ISdkConfigure) func() (lsclient.ISdkAuthentication, lserr.IError) {

--- a/client/client_config.go
+++ b/client/client_config.go
@@ -15,6 +15,7 @@ type (
 		GetGLBEndpoint() string
 		GetVNetworkEndpoint() string
 		GetVDnsEndpoint() string
+		GetVdbKafkaEndpoint() string
 		GetUserAgent() string
 		WithUserId(puserId string) ISdkConfigure
 		WithZoneId(pzoneId string) ISdkConfigure
@@ -28,22 +29,24 @@ type (
 		WithVNetworkEndpoint(pvnetworkEndpoint string) ISdkConfigure
 		WithVDnsEndpoint(pvdnsEndpoint string) ISdkConfigure
 		WithGLBEndpoint(pvlbEndpoint string) ISdkConfigure
+		WithVdbKafkaEndpoint(pvdbKafkaEndpoint string) ISdkConfigure
 	}
 )
 
 type sdkConfigure struct {
-	clientId         string
-	clientSecret     string
-	projectId        string
-	zoneId           string
-	userId           string
-	iamEndpoint      string
-	vserverEndpoint  string
-	vlbEndpoint      string
-	glbEndpoint      string
-	vnetworkEndpoint string
-	vdnsEndpoint     string
-	userAgent        string
+	clientId          string
+	clientSecret      string
+	projectId         string
+	zoneId            string
+	userId            string
+	iamEndpoint       string
+	vserverEndpoint   string
+	vlbEndpoint       string
+	glbEndpoint       string
+	vnetworkEndpoint  string
+	vdnsEndpoint      string
+	vdbKafkaEndpoint  string
+	userAgent         string
 }
 
 func (s *sdkConfigure) GetClientId() string {
@@ -88,6 +91,10 @@ func (s *sdkConfigure) GetVNetworkEndpoint() string {
 
 func (s *sdkConfigure) GetVDnsEndpoint() string {
 	return s.vdnsEndpoint
+}
+
+func (s *sdkConfigure) GetVdbKafkaEndpoint() string {
+	return s.vdbKafkaEndpoint
 }
 
 func (s *sdkConfigure) GetUserAgent() string {
@@ -151,5 +158,10 @@ func (s *sdkConfigure) WithVDnsEndpoint(pvdnsEndpoint string) ISdkConfigure {
 
 func (s *sdkConfigure) WithGLBEndpoint(pvlbEndpoint string) ISdkConfigure {
 	s.glbEndpoint = ljutils.NormalizeURL(pvlbEndpoint)
+	return s
+}
+
+func (s *sdkConfigure) WithVdbKafkaEndpoint(pvdbKafkaEndpoint string) ISdkConfigure {
+	s.vdbKafkaEndpoint = ljutils.NormalizeURL(pvdbKafkaEndpoint)
 	return s
 }

--- a/client/client_config.go
+++ b/client/client_config.go
@@ -16,6 +16,7 @@ type (
 		GetVNetworkEndpoint() string
 		GetVDnsEndpoint() string
 		GetVdbKafkaEndpoint() string
+		GetVdbOpenSearchEndpoint() string
 		GetUserAgent() string
 		WithUserId(puserId string) ISdkConfigure
 		WithZoneId(pzoneId string) ISdkConfigure
@@ -30,23 +31,25 @@ type (
 		WithVDnsEndpoint(pvdnsEndpoint string) ISdkConfigure
 		WithGLBEndpoint(pvlbEndpoint string) ISdkConfigure
 		WithVdbKafkaEndpoint(pvdbKafkaEndpoint string) ISdkConfigure
+		WithVdbOpenSearchEndpoint(pvdbOpenSearchEndpoint string) ISdkConfigure
 	}
 )
 
 type sdkConfigure struct {
-	clientId          string
-	clientSecret      string
-	projectId         string
-	zoneId            string
-	userId            string
-	iamEndpoint       string
-	vserverEndpoint   string
-	vlbEndpoint       string
-	glbEndpoint       string
-	vnetworkEndpoint  string
-	vdnsEndpoint      string
-	vdbKafkaEndpoint  string
-	userAgent         string
+	clientId              string
+	clientSecret          string
+	projectId             string
+	zoneId                string
+	userId                string
+	iamEndpoint           string
+	vserverEndpoint       string
+	vlbEndpoint           string
+	glbEndpoint           string
+	vnetworkEndpoint      string
+	vdnsEndpoint          string
+	vdbKafkaEndpoint      string
+	vdbOpenSearchEndpoint string
+	userAgent             string
 }
 
 func (s *sdkConfigure) GetClientId() string {
@@ -95,6 +98,10 @@ func (s *sdkConfigure) GetVDnsEndpoint() string {
 
 func (s *sdkConfigure) GetVdbKafkaEndpoint() string {
 	return s.vdbKafkaEndpoint
+}
+
+func (s *sdkConfigure) GetVdbOpenSearchEndpoint() string {
+	return s.vdbOpenSearchEndpoint
 }
 
 func (s *sdkConfigure) GetUserAgent() string {
@@ -163,5 +170,10 @@ func (s *sdkConfigure) WithGLBEndpoint(pvlbEndpoint string) ISdkConfigure {
 
 func (s *sdkConfigure) WithVdbKafkaEndpoint(pvdbKafkaEndpoint string) ISdkConfigure {
 	s.vdbKafkaEndpoint = ljutils.NormalizeURL(pvdbKafkaEndpoint)
+	return s
+}
+
+func (s *sdkConfigure) WithVdbOpenSearchEndpoint(pvdbOpenSearchEndpoint string) ISdkConfigure {
+	s.vdbOpenSearchEndpoint = ljutils.NormalizeURL(pvdbOpenSearchEndpoint)
 	return s
 }

--- a/client/iclient.go
+++ b/client/iclient.go
@@ -31,4 +31,5 @@ type IClient interface {
 	GLBGateway() lsgateway.IGLBGateway
 	VDnsGateway() lsgateway.IVDnsGateway
 	VDBKafkaGateway() lsgateway.IVDBKafkaGateway
+	VDBOpenSearchGateway() lsgateway.IVDBOpenSearchGateway
 }

--- a/client/iclient.go
+++ b/client/iclient.go
@@ -30,4 +30,5 @@ type IClient interface {
 	VNetworkGateway() lsgateway.IVNetworkGateway
 	GLBGateway() lsgateway.IGLBGateway
 	VDnsGateway() lsgateway.IVDnsGateway
+	VDBKafkaGateway() lsgateway.IVDBKafkaGateway
 }

--- a/test/kafka_helper_test.go
+++ b/test/kafka_helper_test.go
@@ -1,0 +1,243 @@
+package test
+
+import (
+	larchivezip "archive/zip"
+	lbytes "bytes"
+	lstrings "strings"
+	ltesting "testing"
+
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lskafkaV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka/v1"
+)
+
+const (
+	// All test fixtures are FAKE — modeled after the real sample at
+	// /home/tytv2/tcp-logs-test/user-f7c2e02a-3e82-4990-a4d5-8069fc29cbcd/ but
+	// regenerated with throwaway material so nothing real leaks into the repo.
+	testAuthenCredsUserId = "f7c2e02a-3e82-4990-a4d5-8069fc29cbcd"
+
+	testFakeCACertMTLS   = "-----BEGIN CERTIFICATE-----\nMIIB-FAKE-MTLS-CA\n-----END CERTIFICATE-----\n"
+	testFakeUserCertMTLS = "-----BEGIN CERTIFICATE-----\nMIIB-FAKE-MTLS-USER-CRT\n-----END CERTIFICATE-----\n"
+	testFakeUserKeyMTLS  = "-----BEGIN PRIVATE KEY-----\nMIIB-FAKE-MTLS-USER-KEY\n-----END PRIVATE KEY-----\n"
+
+	testFakeCACertSASL = "-----BEGIN CERTIFICATE-----\nMIIB-FAKE-SASL-CA\n-----END CERTIFICATE-----\n"
+	testFakeSASLPwd    = "fakeSaslPassword12345"
+	testFakeSASLUser   = "kafkauser-50077359-71df-4785-84b6-55364bedf444"
+	testFakeJaasConfig = `org.apache.kafka.common.security.scram.ScramLoginModule required username="kafkauser-50077359-71df-4785-84b6-55364bedf444" password="fakeSaslPassword12345";`
+
+	// Files that should be IGNORED by the parser (Java keystore artifacts + macOS junk).
+	testFakeP12         = "PK\x03\x04 fake p12 content"
+	testFakeKeystorePwd = "garbage12345"
+	testFakeConfigProps = "security.protocol=SSL\nssl.keystore.location=user.p12\n"
+)
+
+// buildTestAuthenCredsZip creates a zip mirroring the real vDB authen-creds layout:
+//
+//	user-{userId}/
+//	├── mtls/
+//	│   ├── ca.crt, ca.p12, ca.password
+//	│   ├── user.crt, user.key, user.p12, user.password
+//	│   └── config.properties
+//	└── sasl/
+//	    ├── ca.crt, ca.p12, ca.password
+//	    ├── password, sasl.jaas.config, config.properties
+func buildTestAuthenCredsZip(t *ltesting.T) []byte {
+	t.Helper()
+	var buf lbytes.Buffer
+	zw := larchivezip.NewWriter(&buf)
+	root := "user-" + testAuthenCredsUserId + "/"
+
+	add := func(path, content string) {
+		w, err := zw.Create(path)
+		if err != nil {
+			t.Fatalf("zip create %s: %v", path, err)
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			t.Fatalf("zip write %s: %v", path, err)
+		}
+	}
+
+	// mtls/
+	add(root+"mtls/ca.crt", testFakeCACertMTLS)
+	add(root+"mtls/user.crt", testFakeUserCertMTLS)
+	add(root+"mtls/user.key", testFakeUserKeyMTLS)
+	add(root+"mtls/ca.p12", testFakeP12)
+	add(root+"mtls/user.p12", testFakeP12)
+	add(root+"mtls/ca.password", testFakeKeystorePwd)
+	add(root+"mtls/user.password", testFakeKeystorePwd)
+	add(root+"mtls/config.properties", testFakeConfigProps)
+
+	// sasl/
+	add(root+"sasl/ca.crt", testFakeCACertSASL)
+	add(root+"sasl/password", testFakeSASLPwd)
+	add(root+"sasl/sasl.jaas.config", testFakeJaasConfig)
+	add(root+"sasl/ca.p12", testFakeP12)
+	add(root+"sasl/ca.password", testFakeKeystorePwd)
+	add(root+"sasl/config.properties", testFakeConfigProps)
+
+	// macOS junk
+	add(root+".DS_Store", "should be skipped")
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestParseAuthenCredsZip_BothMTLSAndSASL(t *ltesting.T) {
+	zipBytes := buildTestAuthenCredsZip(t)
+
+	creds, err := lskafkaV1.ParseAuthenCredsZip(zipBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if creds.UserId != testAuthenCredsUserId {
+		t.Errorf("UserId = %q, want %q", creds.UserId, testAuthenCredsUserId)
+	}
+
+	if !creds.HasMTLS() {
+		t.Fatal("expected HasMTLS() = true")
+	}
+	if got := string(creds.MTLS.CACert); got != testFakeCACertMTLS {
+		t.Errorf("MTLS.CACert mismatch:\n  got:  %q\n  want: %q", got, testFakeCACertMTLS)
+	}
+	if got := string(creds.MTLS.UserCert); got != testFakeUserCertMTLS {
+		t.Errorf("MTLS.UserCert mismatch")
+	}
+	if got := string(creds.MTLS.UserKey); got != testFakeUserKeyMTLS {
+		t.Errorf("MTLS.UserKey mismatch")
+	}
+
+	if !creds.HasSASL() {
+		t.Fatal("expected HasSASL() = true")
+	}
+	if creds.SASL.Mechanism != "SCRAM-SHA-512" {
+		t.Errorf("SASL.Mechanism = %q, want SCRAM-SHA-512", creds.SASL.Mechanism)
+	}
+	if creds.SASL.Username != testFakeSASLUser {
+		t.Errorf("SASL.Username = %q, want %q", creds.SASL.Username, testFakeSASLUser)
+	}
+	if creds.SASL.Password != testFakeSASLPwd {
+		t.Errorf("SASL.Password = %q, want %q", creds.SASL.Password, testFakeSASLPwd)
+	}
+	if string(creds.SASL.CACert) != testFakeCACertSASL {
+		t.Errorf("SASL.CACert mismatch")
+	}
+}
+
+func TestParseAuthenCredsZip_EmptyBytes(t *ltesting.T) {
+	if _, err := lskafkaV1.ParseAuthenCredsZip(nil); err == nil {
+		t.Fatal("expected error for nil input")
+	}
+	if _, err := lskafkaV1.ParseAuthenCredsZip([]byte{}); err == nil {
+		t.Fatal("expected error for empty bytes")
+	}
+}
+
+func TestParseAuthenCredsZip_OnlyMTLS(t *ltesting.T) {
+	var buf lbytes.Buffer
+	zw := larchivezip.NewWriter(&buf)
+	root := "user-onlymtls/"
+	_, _ = zw.Create(root + "mtls/ca.crt")
+	w, _ := zw.Create(root + "mtls/user.crt")
+	_, _ = w.Write([]byte(testFakeUserCertMTLS))
+	w, _ = zw.Create(root + "mtls/user.key")
+	_, _ = w.Write([]byte(testFakeUserKeyMTLS))
+	w, _ = zw.Create(root + "mtls/ca.crt")
+	_, _ = w.Write([]byte(testFakeCACertMTLS))
+	_ = zw.Close()
+
+	creds, err := lskafkaV1.ParseAuthenCredsZip(buf.Bytes())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !creds.HasMTLS() {
+		t.Error("expected HasMTLS() = true")
+	}
+	if creds.HasSASL() {
+		t.Error("expected HasSASL() = false")
+	}
+}
+
+func TestBuildBootstrapServers_MTLSPublic(t *ltesting.T) {
+	cluster := &lsentity.KafkaCluster{
+		Id:           "test-cluster-mtls",
+		PublicAccess: true,
+		FloatingIps:  []string{"61.28.236.199", "61.28.235.33", "61.28.235.4"},
+	}
+
+	got, err := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthMTLS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "61.28.236.199:9194,61.28.235.33:9194,61.28.235.4:9194"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildBootstrapServers_SASLPublic(t *ltesting.T) {
+	cluster := &lsentity.KafkaCluster{
+		Id:           "test-cluster-sasl",
+		PublicAccess: true,
+		FloatingIps:  []string{"61.28.236.199", "61.28.235.33", "61.28.235.4"},
+	}
+
+	got, err := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthSASL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "61.28.236.199:9196,61.28.235.33:9196,61.28.235.4:9196"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestBuildBootstrapServers_PublicAccessDisabled(t *ltesting.T) {
+	cluster := &lsentity.KafkaCluster{
+		Id:           "test-cluster",
+		PublicAccess: false,
+		FloatingIps:  []string{"61.28.236.199"},
+	}
+
+	_, err := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthMTLS)
+	if err == nil {
+		t.Fatal("expected error when publicAccess=false")
+	}
+	if !lstrings.Contains(err.Error(), "publicAccess") {
+		t.Errorf("error %q should mention publicAccess", err.Error())
+	}
+}
+
+func TestBuildBootstrapServers_NoFloatingIPs(t *ltesting.T) {
+	cluster := &lsentity.KafkaCluster{
+		Id:           "test-cluster",
+		PublicAccess: true,
+		FloatingIps:  []string{},
+	}
+
+	_, err := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthMTLS)
+	if err == nil {
+		t.Fatal("expected error when floatingIps is empty")
+	}
+}
+
+func TestBuildBootstrapServers_UnsupportedAuthMode(t *ltesting.T) {
+	cluster := &lsentity.KafkaCluster{
+		Id:           "test-cluster",
+		PublicAccess: true,
+		FloatingIps:  []string{"61.28.236.199"},
+	}
+
+	_, err := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthMode("plaintext"))
+	if err == nil {
+		t.Fatal("expected error for unsupported auth mode")
+	}
+}
+
+func TestBuildBootstrapServers_NilCluster(t *ltesting.T) {
+	if _, err := lskafkaV1.BuildBootstrapServers(nil, lskafkaV1.AuthMTLS); err == nil {
+		t.Fatal("expected error for nil cluster")
+	}
+}

--- a/test/kafka_integration_test.go
+++ b/test/kafka_integration_test.go
@@ -1,0 +1,305 @@
+package test
+
+import (
+	larchivezip "archive/zip"
+	lbytes "bytes"
+	lctx "context"
+	lfmt "fmt"
+	los "os"
+	lstrings "strings"
+	ltesting "testing"
+	ltime "time"
+
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/client"
+	lskafkaV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka/v1"
+)
+
+const (
+	envIamEndpoint      = "https://iamapis.vngcloud.vn/accounts-api"
+	envVdbKafkaEndpoint = "https://vdb-gateway.vngcloud.vn"
+
+	// Opt-in toggle to run the destructive CreateTopic test against real vDB.
+	// Set VKS_TEST_CREATE_TOPIC=1 to enable. Skipped by default.
+	envCreateTopicToggle = "VKS_TEST_CREATE_TOPIC"
+)
+
+// validKafkaSdkConfig builds an SDK client wired to IAM + vDB Kafka endpoints
+// using credentials in test/env.yaml. Other endpoints are unset — these tests
+// only touch the kafka gateway.
+func validKafkaSdkConfig(t *ltesting.T) lsclient.IClient {
+	t.Helper()
+	clientId, clientSecret := getEnv()
+	if clientId == "" || clientSecret == "" {
+		t.Skip("env.yaml missing VNGCLOUD_CLIENT_ID / VNGCLOUD_CLIENT_SECRET — skipping integration test")
+	}
+
+	portalUserId := getValueOfEnv("VNGCLOUD_USER_ID")
+	if portalUserId == "" {
+		t.Skip("env.yaml missing VNGCLOUD_USER_ID — skipping integration test")
+	}
+
+	sdkCfg := lsclient.NewSdkConfigure().
+		WithClientId(clientId).
+		WithClientSecret(clientSecret).
+		WithUserId(portalUserId).
+		WithIamEndpoint(envIamEndpoint).
+		WithVdbKafkaEndpoint(envVdbKafkaEndpoint)
+
+	return lsclient.NewClient(lctx.TODO()).
+		WithRetryCount(1).
+		WithSleep(2 * ltime.Second).
+		Configure(sdkCfg)
+}
+
+func TestKafka_ListClusters(t *ltesting.T) {
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil {
+		t.Fatal("expected non-nil response (may be empty slice)")
+	}
+
+	t.Logf("found %d kafka cluster(s) for portal user", len(*clusters))
+	for i, cl := range *clusters {
+		t.Logf("  [%d] id=%s name=%q status=%s mtls=%v sasl=%v public=%v floatingIps=%v",
+			i, cl.Id, cl.Name, cl.Status, cl.MtlsAuthen, cl.SaslAuthen, cl.PublicAccess, cl.FloatingIps)
+	}
+}
+
+func TestKafka_GetCluster(t *ltesting.T) {
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no kafka clusters in account — skipping GetCluster")
+	}
+
+	clusterId := (*clusters)[0].Id
+	got, gerr := svc.GetCluster(lskafkaV1.NewGetClusterRequest(clusterId))
+	if gerr != nil {
+		t.Fatalf("GetCluster(%s) failed: %+v", clusterId, gerr.GetError())
+	}
+	if got.Id != clusterId {
+		t.Errorf("cluster id mismatch: got %s, want %s", got.Id, clusterId)
+	}
+	t.Logf("cluster %s: name=%q status=%s brokers=%d mtls=%v sasl=%v public=%v",
+		got.Id, got.Name, got.Status, got.KafkaBrokerCount, got.MtlsAuthen, got.SaslAuthen, got.PublicAccess)
+	t.Logf("  fixedIps=%v floatingIps=%v", got.FixedIps, got.FloatingIps)
+}
+
+func TestKafka_ListUsers(t *ltesting.T) {
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no kafka clusters in account")
+	}
+	clusterId := (*clusters)[0].Id
+
+	users, uerr := svc.ListUsers(lskafkaV1.NewListUsersRequest(clusterId))
+	if uerr != nil {
+		t.Fatalf("ListUsers(%s) failed: %+v", clusterId, uerr.GetError())
+	}
+	t.Logf("found %d user(s) on cluster %s", len(*users), clusterId)
+	for i, u := range *users {
+		t.Logf("  [%d] id=%s name=%q mtls=%v sasl=%v produceAll=%v produceTopics=%v",
+			i, u.Id, u.Name, u.MtlsAuthen, u.SaslAuthen, u.ProduceAll, u.ProduceTopicNames)
+	}
+}
+
+func TestKafka_ListTopics(t *ltesting.T) {
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no kafka clusters in account")
+	}
+	clusterId := (*clusters)[0].Id
+
+	topics, terr := svc.ListTopics(lskafkaV1.NewListTopicsRequest(clusterId))
+	if terr != nil {
+		t.Fatalf("ListTopics(%s) failed: %+v", clusterId, terr.GetError())
+	}
+	t.Logf("found %d topic(s) on cluster %s", len(*topics), clusterId)
+	for i, tp := range *topics {
+		t.Logf("  [%d] name=%q partitions=%d replicas=%d retentionSec=%d status=%s",
+			i, tp.Name, tp.Partitions, tp.Replicas, tp.RetentionSeconds, tp.Status)
+	}
+}
+
+func TestKafka_GetUserAuthenCreds(t *ltesting.T) {
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no kafka clusters in account")
+	}
+
+	// Find a cluster that has at least one user (downloading creds requires a user id)
+	var clusterId, userId string
+	for _, cl := range *clusters {
+		if cl.Status != "ACTIVE" {
+			continue
+		}
+		users, uerr := svc.ListUsers(lskafkaV1.NewListUsersRequest(cl.Id))
+		if uerr != nil || users == nil || len(*users) == 0 {
+			continue
+		}
+		clusterId = cl.Id
+		userId = (*users)[0].Id
+		t.Logf("using cluster=%s user=%s for authen-creds test", clusterId, userId)
+		break
+	}
+	if clusterId == "" {
+		t.Skip("no active cluster with a user — skipping authen-creds test")
+	}
+
+	zipBytes, zerr := svc.GetUserAuthenCreds(lskafkaV1.NewGetUserAuthenCredsRequest(clusterId, userId))
+	if zerr != nil {
+		t.Fatalf("GetUserAuthenCreds(%s, %s) failed: %+v", clusterId, userId, zerr.GetError())
+	}
+	if len(zipBytes) == 0 {
+		t.Fatal("expected non-empty zip bytes")
+	}
+	t.Logf("downloaded authen-creds zip: %d bytes", len(zipBytes))
+
+	// Verify it's actually a zip
+	zr, zererr := larchivezip.NewReader(lbytes.NewReader(zipBytes), int64(len(zipBytes)))
+	if zererr != nil {
+		t.Fatalf("response is not a valid zip: %v", zererr)
+	}
+	t.Logf("zip contains %d entries:", len(zr.File))
+	for _, f := range zr.File {
+		t.Logf("  %s (%d bytes)", f.Name, f.UncompressedSize64)
+	}
+
+	// Parse via SDK helper
+	creds, perr := lskafkaV1.ParseAuthenCredsZip(zipBytes)
+	if perr != nil {
+		t.Fatalf("ParseAuthenCredsZip failed: %v", perr)
+	}
+	t.Logf("parsed userId=%s hasMTLS=%v hasSASL=%v", creds.UserId, creds.HasMTLS(), creds.HasSASL())
+	if creds.HasMTLS() {
+		t.Logf("  mtls ca.crt=%d bytes, user.crt=%d bytes, user.key=%d bytes",
+			len(creds.MTLS.CACert), len(creds.MTLS.UserCert), len(creds.MTLS.UserKey))
+	}
+	if creds.HasSASL() {
+		t.Logf("  sasl username=%s mechanism=%s password=%d chars",
+			creds.SASL.Username, creds.SASL.Mechanism, len(creds.SASL.Password))
+	}
+
+	// Build bootstrap servers from cluster info
+	cluster, gerr := svc.GetCluster(lskafkaV1.NewGetClusterRequest(clusterId))
+	if gerr != nil {
+		t.Fatalf("GetCluster failed: %+v", gerr.GetError())
+	}
+	if cluster.PublicAccess && len(cluster.FloatingIps) > 0 {
+		if cluster.MtlsAuthen {
+			if brokers, berr := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthMTLS); berr != nil {
+				t.Errorf("BuildBootstrapServers(mTLS) failed: %v", berr)
+			} else {
+				t.Logf("  bootstrap mTLS: %s", brokers)
+			}
+		}
+		if cluster.SaslAuthen {
+			if brokers, berr := lskafkaV1.BuildBootstrapServers(cluster, lskafkaV1.AuthSASL); berr != nil {
+				t.Errorf("BuildBootstrapServers(SASL) failed: %v", berr)
+			} else {
+				t.Logf("  bootstrap SASL: %s", brokers)
+			}
+		}
+	} else {
+		t.Logf("  cluster public access disabled — skipping BuildBootstrapServers (V1 only supports public)")
+	}
+}
+
+// TestKafka_CreateTopic actually mutates the cluster. Opt-in only.
+// Run with:  VKS_TEST_CREATE_TOPIC=1 go test ...
+// Optional VKS_TEST_CLUSTER_NAME=<name> picks a specific cluster (else uses index 0).
+func TestKafka_CreateTopic(t *ltesting.T) {
+	if los.Getenv(envCreateTopicToggle) != "1" {
+		t.Skipf("destructive — set %s=1 to enable", envCreateTopicToggle)
+	}
+	c := validKafkaSdkConfig(t)
+	svc := c.VDBKafkaGateway().V1().KafkaService()
+
+	clusters, err := svc.ListClusters(lskafkaV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no kafka clusters in account")
+	}
+
+	wantName := los.Getenv("VKS_TEST_CLUSTER_NAME")
+	var clusterId string
+	if wantName != "" {
+		for _, cl := range *clusters {
+			if cl.Name == wantName {
+				clusterId = cl.Id
+				t.Logf("selected cluster by name: %s (id=%s)", cl.Name, cl.Id)
+				break
+			}
+		}
+		if clusterId == "" {
+			t.Fatalf("no cluster with name=%q found", wantName)
+		}
+	} else {
+		clusterId = (*clusters)[0].Id
+		t.Logf("using cluster index 0: %s", clusterId)
+	}
+
+	topicName := lfmt.Sprintf("vks-sdk-test-%d", ltime.Now().Unix())
+	topic, terr := svc.CreateTopic(lskafkaV1.NewCreateTopicRequest(clusterId).
+		WithName(topicName).
+		WithPartitions(1).
+		WithReplicas(1))
+	if terr != nil {
+		// Many vDB clusters have replicas constraint; surface error verbatim
+		t.Fatalf("CreateTopic(%s) failed: %+v", topicName, terr.GetError())
+	}
+	t.Logf("created topic: name=%s id=%s status=%s partitions=%d replicas=%d retentionSec=%d",
+		topic.Name, topic.Id, topic.Status, topic.Partitions, topic.Replicas, topic.RetentionSeconds)
+
+	if !lstrings.Contains(topic.Name, "vks-sdk-test-") {
+		t.Errorf("topic name not preserved: got %s", topic.Name)
+	}
+
+	// Verify via ListTopics
+	topics, lerr := svc.ListTopics(lskafkaV1.NewListTopicsRequest(clusterId))
+	if lerr != nil {
+		t.Errorf("ListTopics after create failed: %+v", lerr.GetError())
+		return
+	}
+	found := false
+	for _, tp := range *topics {
+		if tp.Name == topicName {
+			found = true
+			t.Logf("verified via ListTopics: found %s id=%s status=%s", tp.Name, tp.Id, tp.Status)
+			break
+		}
+	}
+	if !found {
+		t.Errorf("created topic %s not found in ListTopics", topicName)
+	}
+}

--- a/test/opensearch_integration_test.go
+++ b/test/opensearch_integration_test.go
@@ -1,0 +1,130 @@
+package test
+
+import (
+	lctx "context"
+	ltesting "testing"
+	ltime "time"
+
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/client"
+	lsopensearchV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/opensearch/v1"
+)
+
+const envVdbOpenSearchEndpoint = "https://vdb.console.vngcloud.vn"
+
+// validOpenSearchSdkConfig builds an SDK client wired to IAM + vDB OpenSearch
+// endpoints. Distinct from validKafkaSdkConfig because the OS gateway also
+// needs projectId (paths embed it).
+func validOpenSearchSdkConfig(t *ltesting.T) lsclient.IClient {
+	t.Helper()
+	clientId, clientSecret := getEnv()
+	if clientId == "" || clientSecret == "" {
+		t.Skip("env.yaml missing VNGCLOUD_CLIENT_ID / VNGCLOUD_CLIENT_SECRET")
+	}
+	portalUserId := getValueOfEnv("VNGCLOUD_USER_ID")
+	projectId := getValueOfEnv("VNGCLOUD_PROJECT_ID")
+	if portalUserId == "" || projectId == "" {
+		t.Skip("env.yaml missing VNGCLOUD_USER_ID / VNGCLOUD_PROJECT_ID")
+	}
+
+	sdkCfg := lsclient.NewSdkConfigure().
+		WithClientId(clientId).
+		WithClientSecret(clientSecret).
+		WithUserId(portalUserId).
+		WithProjectId(projectId).
+		WithIamEndpoint(envIamEndpoint).
+		WithVdbOpenSearchEndpoint(envVdbOpenSearchEndpoint)
+
+	return lsclient.NewClient(lctx.TODO()).
+		WithRetryCount(1).
+		WithSleep(2 * ltime.Second).
+		Configure(sdkCfg)
+}
+
+func TestOpenSearch_ListClusters(t *ltesting.T) {
+	c := validOpenSearchSdkConfig(t)
+	svc := c.VDBOpenSearchGateway().V1().OpenSearchService()
+
+	clusters, err := svc.ListClusters(lsopensearchV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil {
+		t.Fatal("expected non-nil response")
+	}
+	t.Logf("found %d open-search cluster(s)", len(*clusters))
+	for i, cl := range *clusters {
+		t.Logf("  [%d] id=%s name=%q status=%s version=%s nodes=%d tls=%v public=%v private=%v region=%s",
+			i, cl.Id, cl.Name, cl.Status, cl.Version, cl.NumberOfNodes,
+			cl.EnableTls, cl.PublicAccess, cl.PrivateAccess, cl.Region)
+		t.Logf("      package=%s ram=%dGB cpu=%d storage=%dGB type=%s",
+			cl.PackageDetail.Name, cl.PackageDetail.Ram, cl.PackageDetail.Cpu,
+			cl.StorageSize, cl.StorageType.Name)
+	}
+}
+
+func TestOpenSearch_ListEndpoints(t *ltesting.T) {
+	c := validOpenSearchSdkConfig(t)
+	svc := c.VDBOpenSearchGateway().V1().OpenSearchService()
+
+	clusters, err := svc.ListClusters(lsopensearchV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no clusters")
+	}
+	clusterId := (*clusters)[0].Id
+
+	eps, eerr := svc.ListEndpoints(lsopensearchV1.NewListEndpointsRequest(clusterId))
+	if eerr != nil {
+		t.Fatalf("ListEndpoints(%s) failed: %+v", clusterId, eerr.GetError())
+	}
+	t.Logf("cluster %s has %d endpoint(s):", clusterId, len(*eps))
+	for i, ep := range *eps {
+		t.Logf("  [%d] type=%s url=%s private=%v cidrs=%v", i, ep.Type, ep.Url, ep.Private, ep.Cidrs)
+	}
+
+	// Sanity: there should be at least one log-type endpoint usable by workers
+	var logEp string
+	for _, ep := range *eps {
+		if ep.IsLogIngest() {
+			logEp = ep.Url
+			break
+		}
+	}
+	if logEp == "" {
+		t.Errorf("no log-type endpoint found — worker bulk write target unknown")
+	} else {
+		t.Logf("worker would use log endpoint: %s", logEp)
+	}
+}
+
+func TestOpenSearch_GetCluster(t *ltesting.T) {
+	c := validOpenSearchSdkConfig(t)
+	svc := c.VDBOpenSearchGateway().V1().OpenSearchService()
+
+	clusters, err := svc.ListClusters(lsopensearchV1.NewListClustersRequest())
+	if err != nil {
+		t.Fatalf("ListClusters failed: %+v", err.GetError())
+	}
+	if clusters == nil || len(*clusters) == 0 {
+		t.Skip("no open-search clusters — skipping GetCluster")
+	}
+	want := (*clusters)[0]
+
+	got, gerr := svc.GetCluster(lsopensearchV1.NewGetClusterRequest(want.Id))
+	if gerr != nil {
+		t.Fatalf("GetCluster(%s) failed: %+v", want.Id, gerr.GetError())
+	}
+	if got.Id != want.Id {
+		t.Errorf("id mismatch: got=%s want=%s", got.Id, want.Id)
+	}
+	t.Logf("cluster %s: name=%q status=%s version=%s nodes=%d storage=%dGB tls=%v public=%v",
+		got.Id, got.Name, got.Status, got.Version, got.NumberOfNodes,
+		got.StorageSize, got.EnableTls, got.PublicAccess)
+	t.Logf("  vpc=%s/%s subnet=%s vpcDns=%v encrypt=%v",
+		got.VpcId, got.VpcCidr, got.SubnetId, got.EnableVpcDns, got.EncryptVolume)
+	t.Logf("  package=%s (%dGB ram, %d cpu, %s) storage=%s billing=%s",
+		got.PackageDetail.Name, got.PackageDetail.Ram, got.PackageDetail.Cpu,
+		got.PackageDetail.NetworkPerformance, got.StorageType.Name, got.BillingStatus.Status)
+}

--- a/vngcloud/client/http.go
+++ b/vngcloud/client/http.go
@@ -171,6 +171,9 @@ func (s *httpClient) DoRequest(purl string, preq IRequest) (*lreq.Response, lser
 		}
 
 		if preq.ContainsOkCode(resp.StatusCode) {
+			if bytesPtr := preq.GetBytesResponse(); bytesPtr != nil {
+				*bytesPtr = resp.Bytes()
+			}
 			return resp, nil
 		}
 

--- a/vngcloud/client/iclient.go
+++ b/vngcloud/client/iclient.go
@@ -25,6 +25,7 @@ type IRequest interface {
 	WithJsonBody(pjsonBody interface{}) IRequest
 	WithJsonResponse(pjsonResponse interface{}) IRequest
 	WithJsonError(pjsonError interface{}) IRequest
+	WithBytesResponse(pbytesResponse *[]byte) IRequest
 	WithRequestMethod(pmethod requestMethod) IRequest
 	WithSkipAuth(pskipAuth bool) IRequest
 	WithHeader(pkey, pvalue string) IRequest
@@ -37,6 +38,7 @@ type IRequest interface {
 	GetOmitHeaders() ljset.Set[string]
 	GetJsonResponse() interface{}
 	GetJsonError() interface{}
+	GetBytesResponse() *[]byte
 
 	SetJsonResponse(pjsonResponse interface{})
 	SetJsonError(pjsonError interface{})

--- a/vngcloud/client/request.go
+++ b/vngcloud/client/request.go
@@ -3,14 +3,15 @@ package client
 import ljset "github.com/cuongpiger/joat/data-structure/set"
 
 type request struct {
-	JsonBody     interface{}
-	JsonResponse interface{}
-	JsonError    interface{}
-	MoreHeaders  map[string]string
-	OmitHeaders  ljset.Set[string]
-	OkCodes      ljset.Set[int]
-	Method       requestMethod
-	SkipAuth     bool
+	JsonBody      interface{}
+	JsonResponse  interface{}
+	JsonError     interface{}
+	BytesResponse *[]byte
+	MoreHeaders   map[string]string
+	OmitHeaders   ljset.Set[string]
+	OkCodes       ljset.Set[int]
+	Method        requestMethod
+	SkipAuth      bool
 }
 
 type requestMethod string
@@ -53,6 +54,11 @@ func (s *request) WithJsonError(pjsonError interface{}) IRequest {
 	return s
 }
 
+func (s *request) WithBytesResponse(pbytesResponse *[]byte) IRequest {
+	s.BytesResponse = pbytesResponse
+	return s
+}
+
 func (s *request) WithRequestMethod(pmethod requestMethod) IRequest {
 	s.Method = pmethod
 	return s
@@ -85,6 +91,10 @@ func (s *request) GetOmitHeaders() ljset.Set[string] {
 
 func (s *request) GetJsonResponse() interface{} {
 	return s.JsonResponse
+}
+
+func (s *request) GetBytesResponse() *[]byte {
+	return s.BytesResponse
 }
 
 func (s *request) SetJsonResponse(pjsonResponse interface{}) {

--- a/vngcloud/entity/kafka_authen_creds.go
+++ b/vngcloud/entity/kafka_authen_creds.go
@@ -1,0 +1,36 @@
+package entity
+
+// KafkaAuthenCreds is the result of unzipping the response of
+// GET /vdb-kafka/clusters/{clusterId}/users/{userId}/authen-creds.
+// The zip always contains both mtls/ and sasl/ subdirectories so the caller
+// can pick the auth mode at consume time (V1: mtls preferred).
+type KafkaAuthenCreds struct {
+	UserId string          // folder root inside the zip: user-{vdb_user_id}
+	MTLS   *KafkaMTLSCreds // nil if zip does not contain mtls/
+	SASL   *KafkaSASLCreds // nil if zip does not contain sasl/
+}
+
+// KafkaMTLSCreds holds PEM-encoded bytes for kafka-go's tls.Config.
+// PKCS12 files (.p12) and their passwords are intentionally dropped — those
+// are Java keystore artifacts unused by Go clients.
+type KafkaMTLSCreds struct {
+	CACert   []byte
+	UserCert []byte
+	UserKey  []byte
+}
+
+// KafkaSASLCreds carries SCRAM-SHA-512 credentials plus CA for SASL_SSL.
+type KafkaSASLCreds struct {
+	CACert    []byte
+	Mechanism string // "SCRAM-SHA-512" (only supported mechanism today)
+	Username  string
+	Password  string
+}
+
+func (s *KafkaAuthenCreds) HasMTLS() bool {
+	return s.MTLS != nil && len(s.MTLS.CACert) > 0 && len(s.MTLS.UserCert) > 0 && len(s.MTLS.UserKey) > 0
+}
+
+func (s *KafkaAuthenCreds) HasSASL() bool {
+	return s.SASL != nil && len(s.SASL.CACert) > 0 && s.SASL.Username != "" && s.SASL.Password != ""
+}

--- a/vngcloud/entity/kafka_cluster.go
+++ b/vngcloud/entity/kafka_cluster.go
@@ -1,0 +1,64 @@
+package entity
+
+const (
+	KafkaClusterStatusActive   = "ACTIVE"
+	KafkaClusterStatusCreating = "CREATING"
+	KafkaClusterStatusError    = "ERROR"
+	KafkaClusterStatusStopped  = "STOPPED"
+)
+
+type (
+	KafkaCluster struct {
+		Id                   string
+		Name                 string
+		Tags                 map[string]string
+		KafkaVersion         string
+		ServerFlavorId       string
+		KafkaBrokerCount     int32
+		KafkaStorageType     string
+		KafkaStorageSize     int32
+		KafkaStorageUsage    []int64
+		VserverProjectId     string
+		NetworkId            string
+		SubnetId             string
+		FixedIps             []string
+		FloatingIps          []string
+		PublicAccess         bool
+		MtlsAuthen           bool
+		SaslAuthen           bool
+		SecurityGroupRules   []KafkaSecurityGroupRule
+		ConfigGroupVersionId string
+		PortalUserId         int32
+		Status               string
+		ErrorMessage         string
+		CreatedAt            string
+		EncryptionVolume     bool
+		Iops                 int32
+		VolumeType           string
+		VolumeTypeZoneId     string
+		Ram                  int32
+		Vcpus                int32
+		InstanceType         string
+	}
+
+	KafkaSecurityGroupRule struct {
+		Id             string
+		Direction      string
+		Protocol       string
+		PortRangeMin   int32
+		PortRangeMax   int32
+		RemoteIpPrefix string
+	}
+)
+
+func (s *KafkaCluster) IsActive() bool {
+	return s.Status == KafkaClusterStatusActive
+}
+
+func (s *KafkaCluster) HasPublicEndpoint() bool {
+	return s.PublicAccess && len(s.FloatingIps) > 0
+}
+
+func (s *KafkaCluster) HasPrivateEndpoint() bool {
+	return len(s.FixedIps) > 0
+}

--- a/vngcloud/entity/kafka_topic.go
+++ b/vngcloud/entity/kafka_topic.go
@@ -1,0 +1,24 @@
+package entity
+
+const (
+	KafkaTopicStatusActive   = "ACTIVE"
+	KafkaTopicStatusCreating = "CREATING"
+	KafkaTopicStatusError    = "ERROR"
+)
+
+type KafkaTopic struct {
+	Id               string
+	ClusterId        string
+	Name             string
+	Partitions       int32
+	Replicas         int32
+	RetentionSeconds int64
+	RetentionBytes   int64
+	PortalUserId     int32
+	Status           string
+	CreatedAt        string
+}
+
+func (s *KafkaTopic) IsActive() bool {
+	return s.Status == KafkaTopicStatusActive
+}

--- a/vngcloud/entity/kafka_user.go
+++ b/vngcloud/entity/kafka_user.go
@@ -1,0 +1,49 @@
+package entity
+
+const (
+	KafkaUserStatusActive   = "ACTIVE"
+	KafkaUserStatusCreating = "CREATING"
+	KafkaUserStatusError    = "ERROR"
+)
+
+type KafkaUser struct {
+	Id                       string
+	ClusterId                string
+	Name                     string
+	ProduceTopicNames        []string
+	ProduceAll               bool
+	ConsumeTopicNames        []string
+	ConsumeAll               bool
+	ProduceConsumeTopicNames []string
+	ProduceConsumeAll        bool
+	AdminTopicNames          []string
+	AdminAll                 bool
+	MtlsAuthen               bool
+	SaslAuthen               bool
+	PortalUserId             int32
+	OldStatus                string
+	Status                   string
+	CreatedAt                string
+}
+
+func (s *KafkaUser) CanProduceTo(topic string) bool {
+	if s.ProduceAll || s.ProduceConsumeAll || s.AdminAll {
+		return true
+	}
+	for _, t := range s.ProduceTopicNames {
+		if t == topic {
+			return true
+		}
+	}
+	for _, t := range s.ProduceConsumeTopicNames {
+		if t == topic {
+			return true
+		}
+	}
+	for _, t := range s.AdminTopicNames {
+		if t == topic {
+			return true
+		}
+	}
+	return false
+}

--- a/vngcloud/entity/opensearch_cluster.go
+++ b/vngcloud/entity/opensearch_cluster.go
@@ -1,0 +1,106 @@
+package entity
+
+const (
+	OpenSearchClusterStatusActive   = "ACTIVE"
+	OpenSearchClusterStatusCreating = "CREATING"
+	OpenSearchClusterStatusError    = "ERROR"
+)
+
+type (
+	OpenSearchCluster struct {
+		// Id is the full UUID used in API URLs (e.g. op-d0e2c62b-8130-46be-b65e-3375549af42a).
+		// ClusterId is a truncated public-facing identifier — keep both for round-trip parity.
+		Id          string
+		ClusterId   string
+		ProjectId   string
+		Name        string
+		Description string
+		Status      string
+		Version     string
+		Region      string
+
+		NumberOfNodes int32
+		StorageSize   int32
+
+		EnableTls     bool
+		PublicAccess  bool
+		PrivateAccess bool
+		EncryptVolume bool
+		EnableVpcDns  bool
+
+		VpcId    string
+		VpcCidr  string
+		SubnetId string
+
+		PackageId     string
+		StorageTypeId string
+		ConfigGroupId string
+		PortalUserId  int32
+
+		CreatedAt string
+		UpdatedAt string
+		DeletedAt string
+
+		PackageDetail OpenSearchPackageDetail
+		StorageType   OpenSearchStorageType
+		ConfigGroup   OpenSearchConfigGroup
+		BillingStatus OpenSearchBillingStatus
+	}
+
+	OpenSearchPackageDetail struct {
+		Id                 string
+		Name               string
+		Type               string
+		Description        string
+		NetworkPerformance string
+		IsDefault          bool
+		Ram                int32
+		Cpu                int32
+		Platform           string
+	}
+
+	OpenSearchStorageType struct {
+		Id   string
+		Name string
+		Min  int32
+		Max  int32
+	}
+
+	OpenSearchConfigGroup struct {
+		Name    string
+		Version string
+	}
+
+	OpenSearchBillingStatus struct {
+		Status      string
+		RenewPeriod int32
+	}
+
+	OpenSearchEndpoint struct {
+		Url     string
+		Type    string // "dashboard" (:443 UI) or "log" (:9200 REST API)
+		Cidrs   []string
+		Private bool
+	}
+)
+
+const (
+	OpenSearchEndpointTypeDashboard = "dashboard"
+	OpenSearchEndpointTypeLog       = "log"
+)
+
+func (s *OpenSearchEndpoint) IsLogIngest() bool {
+	return s.Type == OpenSearchEndpointTypeLog
+}
+
+func (s *OpenSearchEndpoint) IsDashboard() bool {
+	return s.Type == OpenSearchEndpointTypeDashboard
+}
+
+func (s *OpenSearchCluster) IsActive() bool {
+	return s.Status == OpenSearchClusterStatusActive
+}
+
+func (s *OpenSearchCluster) IsPubliclyAccessible() bool {
+	return s.PublicAccess
+}

--- a/vngcloud/gateway/igateway.go
+++ b/vngcloud/gateway/igateway.go
@@ -8,6 +8,7 @@ import (
 	lskafkaSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka"
 	lslbSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/loadbalancer"
 	lsnetworkSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/network"
+	lsopensearchSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/opensearch"
 	lsportalSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/portal"
 	lsServerSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/server"
 	lsvolumeSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/volume"
@@ -109,4 +110,13 @@ type IVDBKafkaGateway interface {
 
 type IVDBKafkaGatewayV1 interface {
 	KafkaService() lskafkaSvc.IKafkaServiceV1
+}
+
+type IVDBOpenSearchGateway interface {
+	V1() IVDBOpenSearchGatewayV1
+	GetEndpoint() string
+}
+
+type IVDBOpenSearchGatewayV1 interface {
+	OpenSearchService() lsopensearchSvc.IOpenSearchServiceV1
 }

--- a/vngcloud/gateway/igateway.go
+++ b/vngcloud/gateway/igateway.go
@@ -5,6 +5,7 @@ import (
 	lsdnsSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/dns"
 	"github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/glb"
 	lsidentitySvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/identity"
+	lskafkaSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka"
 	lslbSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/loadbalancer"
 	lsnetworkSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/network"
 	lsportalSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/portal"
@@ -99,4 +100,13 @@ type IVDnsGatewayV1 interface {
 
 type IVDnsGatewayInternal interface {
 	DnsService() lsdnsSvc.IVDnsServiceInternal
+}
+
+type IVDBKafkaGateway interface {
+	V1() IVDBKafkaGatewayV1
+	GetEndpoint() string
+}
+
+type IVDBKafkaGatewayV1 interface {
+	KafkaService() lskafkaSvc.IKafkaServiceV1
 }

--- a/vngcloud/gateway/vdb_kafka_gateway.go
+++ b/vngcloud/gateway/vdb_kafka_gateway.go
@@ -1,0 +1,54 @@
+package gateway
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lskafkaSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka"
+)
+
+var _ IVDBKafkaGateway = &vdbKafkaGateway{}
+
+type vdbKafkaGateway struct {
+	endpoint          string
+	vdbKafkaGatewayV1 IVDBKafkaGatewayV1
+}
+
+func NewVDBKafkaGateway(pendpoint, puserId string, phc lsclient.IHttpClient) IVDBKafkaGateway {
+	// vDB Gateway base URL: https://vdb-gateway.vngcloud.vn
+	// Kafka APIs live under /vdb-kafka — there is no API version in the path
+	// (single implicit v1).
+	// puserId is the tenant's portal-user-id (integer as string) which the
+	// gateway requires in every request header even with a valid Bearer token.
+	kafkaSvc := lsclient.NewServiceClient().
+		WithEndpoint(pendpoint + "vdb-kafka").
+		WithClient(phc).
+		WithUserId(puserId)
+
+	return &vdbKafkaGateway{
+		endpoint:          pendpoint,
+		vdbKafkaGatewayV1: NewVDBKafkaGatewayV1(kafkaSvc),
+	}
+}
+
+func (s *vdbKafkaGateway) V1() IVDBKafkaGatewayV1 {
+	return s.vdbKafkaGatewayV1
+}
+
+func (s *vdbKafkaGateway) GetEndpoint() string {
+	return s.endpoint
+}
+
+var _ IVDBKafkaGatewayV1 = &vdbKafkaGatewayV1{}
+
+type vdbKafkaGatewayV1 struct {
+	kafkaService lskafkaSvc.IKafkaServiceV1
+}
+
+func NewVDBKafkaGatewayV1(psvcClient lsclient.IServiceClient) IVDBKafkaGatewayV1 {
+	return &vdbKafkaGatewayV1{
+		kafkaService: lskafkaSvc.NewKafkaServiceV1(psvcClient),
+	}
+}
+
+func (s *vdbKafkaGatewayV1) KafkaService() lskafkaSvc.IKafkaServiceV1 {
+	return s.kafkaService
+}

--- a/vngcloud/gateway/vdb_opensearch_gateway.go
+++ b/vngcloud/gateway/vdb_opensearch_gateway.go
@@ -1,0 +1,55 @@
+package gateway
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsopensearchSvc "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/opensearch"
+)
+
+var _ IVDBOpenSearchGateway = &vdbOpenSearchGateway{}
+
+type vdbOpenSearchGateway struct {
+	endpoint               string
+	vdbOpenSearchGatewayV1 IVDBOpenSearchGatewayV1
+}
+
+// NewVDBOpenSearchGateway wires the vDB OpenSearch service.
+// Base URL example: https://vdb.console.vngcloud.vn — paths are layered under
+// /vdb/open-search/v1/{projectId}/open-search/...
+// puserId is the portal user id required as a request header (same as Kafka).
+// pprojectId is required because OpenSearch paths embed the project id directly.
+func NewVDBOpenSearchGateway(pendpoint, puserId, pprojectId string, phc lsclient.IHttpClient) IVDBOpenSearchGateway {
+	openSearchSvc := lsclient.NewServiceClient().
+		WithEndpoint(pendpoint + "vdb/open-search/v1").
+		WithClient(phc).
+		WithUserId(puserId).
+		WithProjectId(pprojectId)
+
+	return &vdbOpenSearchGateway{
+		endpoint:               pendpoint,
+		vdbOpenSearchGatewayV1: NewVDBOpenSearchGatewayV1(openSearchSvc),
+	}
+}
+
+func (s *vdbOpenSearchGateway) V1() IVDBOpenSearchGatewayV1 {
+	return s.vdbOpenSearchGatewayV1
+}
+
+func (s *vdbOpenSearchGateway) GetEndpoint() string {
+	return s.endpoint
+}
+
+var _ IVDBOpenSearchGatewayV1 = &vdbOpenSearchGatewayV1{}
+
+type vdbOpenSearchGatewayV1 struct {
+	openSearchService lsopensearchSvc.IOpenSearchServiceV1
+}
+
+func NewVDBOpenSearchGatewayV1(psvcClient lsclient.IServiceClient) IVDBOpenSearchGatewayV1 {
+	return &vdbOpenSearchGatewayV1{
+		openSearchService: lsopensearchSvc.NewOpenSearchServiceV1(psvcClient),
+	}
+}
+
+func (s *vdbOpenSearchGatewayV1) OpenSearchService() lsopensearchSvc.IOpenSearchServiceV1 {
+	return s.openSearchService
+}

--- a/vngcloud/services/kafka/ikafka.go
+++ b/vngcloud/services/kafka/ikafka.go
@@ -1,0 +1,16 @@
+package kafka
+
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+	lskafkaSvcV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka/v1"
+)
+
+type IKafkaServiceV1 interface {
+	ListClusters(popts lskafkaSvcV1.IListClustersRequest) (*[]lsentity.KafkaCluster, lserr.IError)
+	GetCluster(popts lskafkaSvcV1.IGetClusterRequest) (*lsentity.KafkaCluster, lserr.IError)
+	ListUsers(popts lskafkaSvcV1.IListUsersRequest) (*[]lsentity.KafkaUser, lserr.IError)
+	GetUserAuthenCreds(popts lskafkaSvcV1.IGetUserAuthenCredsRequest) ([]byte, lserr.IError)
+	ListTopics(popts lskafkaSvcV1.IListTopicsRequest) (*[]lsentity.KafkaTopic, lserr.IError)
+	CreateTopic(popts lskafkaSvcV1.ICreateTopicRequest) (*lsentity.KafkaTopic, lserr.IError)
+}

--- a/vngcloud/services/kafka/kafka.go
+++ b/vngcloud/services/kafka/kafka.go
@@ -1,0 +1,12 @@
+package kafka
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lskafkaSvcV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/kafka/v1"
+)
+
+func NewKafkaServiceV1(psvcClient lsclient.IServiceClient) IKafkaServiceV1 {
+	return &lskafkaSvcV1.KafkaServiceV1{
+		VkafkaClient: psvcClient,
+	}
+}

--- a/vngcloud/services/kafka/v1/base.go
+++ b/vngcloud/services/kafka/v1/base.go
@@ -1,0 +1,9 @@
+package v1
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+)
+
+type KafkaServiceV1 struct {
+	VkafkaClient lsclient.IServiceClient
+}

--- a/vngcloud/services/kafka/v1/helper.go
+++ b/vngcloud/services/kafka/v1/helper.go
@@ -1,0 +1,163 @@
+package v1
+
+import (
+	larchivezip "archive/zip"
+	lbytes "bytes"
+	lerrors "errors"
+	lfmt "fmt"
+	lio "io"
+	lpath "path"
+	lregexp "regexp"
+	lstrings "strings"
+
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+
+type AuthMode string
+
+const (
+	AuthMTLS AuthMode = "mtls"
+	AuthSASL AuthMode = "sasl"
+
+	saslMechanismSCRAMSHA512 = "SCRAM-SHA-512"
+)
+
+// publicPortMatrix maps each auth mode to the broker listener port on public IPs.
+// Confirmed by vDB May 2026:
+//
+//	mTLS public  → :9194
+//	SASL public  → :9196
+//	(private endpoints :9094 / :9096 are deferred to V2)
+var publicPortMatrix = map[AuthMode]int{
+	AuthMTLS: 9194,
+	AuthSASL: 9196,
+}
+
+// jaasUsernamePasswordRe extracts username + password from a SASL JAAS config
+// line like:
+//
+//	org.apache.kafka.common.security.scram.ScramLoginModule required username="..." password="...";
+var jaasUsernamePasswordRe = lregexp.MustCompile(`username="([^"]+)"\s+password="([^"]+)"`)
+
+// ParseAuthenCredsZip decodes the ZIP returned by GetUserAuthenCreds.
+// The zip contains both mtls/ and sasl/ subfolders so the caller can pick the
+// auth mode at consume time. Java keystore artifacts (*.p12 + *.password +
+// config.properties) are skipped — Go clients work directly with PEM bytes.
+func ParseAuthenCredsZip(pzipBytes []byte) (*lsentity.KafkaAuthenCreds, error) {
+	if len(pzipBytes) == 0 {
+		return nil, lerrors.New("empty zip bytes")
+	}
+
+	zr, err := larchivezip.NewReader(lbytes.NewReader(pzipBytes), int64(len(pzipBytes)))
+	if err != nil {
+		return nil, lfmt.Errorf("open zip: %w", err)
+	}
+
+	creds := &lsentity.KafkaAuthenCreds{}
+	mtls := &lsentity.KafkaMTLSCreds{}
+	sasl := &lsentity.KafkaSASLCreds{Mechanism: saslMechanismSCRAMSHA512}
+
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+
+		// Folder root is "user-{uuid}/" — strip the first segment.
+		parts := lstrings.SplitN(f.Name, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		if creds.UserId == "" && lstrings.HasPrefix(parts[0], "user-") {
+			creds.UserId = lstrings.TrimPrefix(parts[0], "user-")
+		}
+
+		rel := parts[1]
+		base := lpath.Base(rel)
+
+		// Skip macOS metadata + Java artifacts (worker doesn't need PKCS12 + keystore passwords).
+		if base == ".DS_Store" || lstrings.HasSuffix(base, ".p12") ||
+			base == "user.password" || base == "ca.password" || base == "config.properties" {
+			continue
+		}
+
+		content, rerr := readZipEntry(f)
+		if rerr != nil {
+			return nil, lfmt.Errorf("read %s: %w", f.Name, rerr)
+		}
+
+		switch {
+		case lstrings.HasPrefix(rel, "mtls/"):
+			switch base {
+			case "ca.crt":
+				mtls.CACert = content
+			case "user.crt":
+				mtls.UserCert = content
+			case "user.key":
+				mtls.UserKey = content
+			}
+
+		case lstrings.HasPrefix(rel, "sasl/"):
+			switch base {
+			case "ca.crt":
+				sasl.CACert = content
+			case "password":
+				sasl.Password = lstrings.TrimSpace(string(content))
+			case "sasl.jaas.config":
+				// Username lives only inside the JAAS line — must parse.
+				if m := jaasUsernamePasswordRe.FindSubmatch(content); len(m) == 3 {
+					sasl.Username = string(m[1])
+					if sasl.Password == "" {
+						sasl.Password = string(m[2])
+					}
+				}
+			}
+		}
+	}
+
+	if mtls.CACert != nil || mtls.UserCert != nil || mtls.UserKey != nil {
+		creds.MTLS = mtls
+	}
+	if sasl.CACert != nil || sasl.Username != "" || sasl.Password != "" {
+		creds.SASL = sasl
+	}
+
+	return creds, nil
+}
+
+func readZipEntry(f *larchivezip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return lio.ReadAll(rc)
+}
+
+// BuildBootstrapServers assembles a comma-separated "ip:port,ip:port,ip:port"
+// string from a KafkaCluster + chosen auth mode.
+//
+// V1 only supports the **public** endpoint set (floatingIps). The cluster must
+// have `publicAccess=true` and ≥1 floating IP; otherwise the function returns
+// an error so the caller can surface a clear "enable public access first"
+// message back to the tenant.
+func BuildBootstrapServers(pcluster *lsentity.KafkaCluster, pauth AuthMode) (string, error) {
+	if pcluster == nil {
+		return "", lerrors.New("cluster is nil")
+	}
+	if !pcluster.PublicAccess {
+		return "", lfmt.Errorf("cluster %s: publicAccess is not enabled — tenant must turn it on via vDB portal", pcluster.Id)
+	}
+	if len(pcluster.FloatingIps) == 0 {
+		return "", lfmt.Errorf("cluster %s: no floating IPs available", pcluster.Id)
+	}
+	port, ok := publicPortMatrix[pauth]
+	if !ok {
+		return "", lfmt.Errorf("unsupported auth mode: %q (expected %q or %q)", pauth, AuthMTLS, AuthSASL)
+	}
+
+	parts := make([]string, 0, len(pcluster.FloatingIps))
+	for _, ip := range pcluster.FloatingIps {
+		parts = append(parts, lfmt.Sprintf("%s:%d", ip, port))
+	}
+	return lstrings.Join(parts, ","), nil
+}

--- a/vngcloud/services/kafka/v1/irequest.go
+++ b/vngcloud/services/kafka/v1/irequest.go
@@ -1,0 +1,38 @@
+package v1
+
+type IListClustersRequest interface {
+	ParseUserAgent() string
+}
+
+type IGetClusterRequest interface {
+	GetClusterId() string
+	ParseUserAgent() string
+}
+
+type IListUsersRequest interface {
+	GetClusterId() string
+	ParseUserAgent() string
+}
+
+type IGetUserAuthenCredsRequest interface {
+	GetClusterId() string
+	GetUserId() string
+	ParseUserAgent() string
+}
+
+type IListTopicsRequest interface {
+	GetClusterId() string
+	ParseUserAgent() string
+}
+
+type ICreateTopicRequest interface {
+	GetClusterId() string
+	GetName() string
+	ToRequestBody() interface{}
+	WithName(pname string) ICreateTopicRequest
+	WithPartitions(ppartitions int32) ICreateTopicRequest
+	WithReplicas(preplicas int32) ICreateTopicRequest
+	WithRetentionSeconds(pretentionSeconds int64) ICreateTopicRequest
+	WithRetentionBytes(pretentionBytes int64) ICreateTopicRequest
+	ParseUserAgent() string
+}

--- a/vngcloud/services/kafka/v1/kafka.go
+++ b/vngcloud/services/kafka/v1/kafka.go
@@ -1,0 +1,138 @@
+package v1
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+// ListClusters returns every Kafka cluster the authenticated portal user owns.
+func (s *KafkaServiceV1) ListClusters(popts IListClustersRequest) (*[]lsentity.KafkaCluster, lserr.IError) {
+	url := listClustersUrl(s.VkafkaClient)
+	resp := new(ListClustersResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp)
+	}
+
+	out := resp.ToEntity()
+	return &out, nil
+}
+
+// GetCluster fetches detail of a specific Kafka cluster.
+func (s *KafkaServiceV1) GetCluster(popts IGetClusterRequest) (*lsentity.KafkaCluster, lserr.IError) {
+	url := getClusterUrl(s.VkafkaClient, popts)
+	resp := new(KafkaClusterResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters("clusterId", popts.GetClusterId())
+	}
+
+	return resp.ToEntity(), nil
+}
+
+// ListUsers returns Kafka users registered on the given cluster.
+func (s *KafkaServiceV1) ListUsers(popts IListUsersRequest) (*[]lsentity.KafkaUser, lserr.IError) {
+	url := listUsersUrl(s.VkafkaClient, popts)
+	resp := new(ListUsersResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters("clusterId", popts.GetClusterId())
+	}
+
+	out := resp.ToEntity()
+	return &out, nil
+}
+
+// GetUserAuthenCreds downloads the authen-creds bundle as a raw ZIP byte slice.
+// The zip contains both mtls/ and sasl/ subfolders — use ParseAuthenCredsZip to extract PEM bytes.
+func (s *KafkaServiceV1) GetUserAuthenCreds(popts IGetUserAuthenCredsRequest) ([]byte, lserr.IError) {
+	url := getUserAuthenCredsUrl(s.VkafkaClient, popts)
+	var zipBytes []byte
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200).
+		WithBytesResponse(&zipBytes).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"clusterId", popts.GetClusterId(),
+				"userId", popts.GetUserId(),
+			)
+	}
+
+	return zipBytes, nil
+}
+
+// ListTopics returns the topics present on the cluster.
+func (s *KafkaServiceV1) ListTopics(popts IListTopicsRequest) (*[]lsentity.KafkaTopic, lserr.IError) {
+	url := listTopicsUrl(s.VkafkaClient, popts)
+	resp := new(ListTopicsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters("clusterId", popts.GetClusterId())
+	}
+
+	out := resp.ToEntity()
+	return &out, nil
+}
+
+// CreateTopic provisions a new topic on the cluster. Returns the TopicDto.
+// Worker uses this for lazy create when sink=Kafka.
+func (s *KafkaServiceV1) CreateTopic(popts ICreateTopicRequest) (*lsentity.KafkaTopic, lserr.IError) {
+	url := createTopicUrl(s.VkafkaClient, popts)
+	resp := new(KafkaTopicResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VkafkaClient.GetUserId()).
+		WithOkCodes(200, 202).
+		WithJsonBody(popts.ToRequestBody()).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VkafkaClient.Post(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"clusterId", popts.GetClusterId(),
+				"topicName", popts.GetName(),
+			)
+	}
+
+	return resp.ToEntity(), nil
+}

--- a/vngcloud/services/kafka/v1/kafka_request.go
+++ b/vngcloud/services/kafka/v1/kafka_request.go
@@ -1,0 +1,154 @@
+package v1
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+// ListClustersRequest -----------------------------------------------------
+
+type ListClustersRequest struct {
+	lscommon.UserAgent
+}
+
+func NewListClustersRequest() IListClustersRequest {
+	return &ListClustersRequest{}
+}
+
+// GetClusterRequest -------------------------------------------------------
+
+type GetClusterRequest struct {
+	ClusterId string
+	lscommon.UserAgent
+}
+
+func NewGetClusterRequest(pclusterId string) IGetClusterRequest {
+	return &GetClusterRequest{ClusterId: pclusterId}
+}
+
+func (s *GetClusterRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+// ListUsersRequest --------------------------------------------------------
+
+type ListUsersRequest struct {
+	ClusterId string
+	lscommon.UserAgent
+}
+
+func NewListUsersRequest(pclusterId string) IListUsersRequest {
+	return &ListUsersRequest{ClusterId: pclusterId}
+}
+
+func (s *ListUsersRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+// GetUserAuthenCredsRequest -----------------------------------------------
+
+type GetUserAuthenCredsRequest struct {
+	ClusterId string
+	UserId    string
+	lscommon.UserAgent
+}
+
+func NewGetUserAuthenCredsRequest(pclusterId, puserId string) IGetUserAuthenCredsRequest {
+	return &GetUserAuthenCredsRequest{ClusterId: pclusterId, UserId: puserId}
+}
+
+func (s *GetUserAuthenCredsRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+func (s *GetUserAuthenCredsRequest) GetUserId() string {
+	return s.UserId
+}
+
+// ListTopicsRequest -------------------------------------------------------
+
+type ListTopicsRequest struct {
+	ClusterId string
+	lscommon.UserAgent
+}
+
+func NewListTopicsRequest(pclusterId string) IListTopicsRequest {
+	return &ListTopicsRequest{ClusterId: pclusterId}
+}
+
+func (s *ListTopicsRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+// CreateTopicRequest ------------------------------------------------------
+
+// CreateTopicRequest maps to TopicCreateRequest in the vDB OpenAPI spec.
+// Constraints (per spec): Partitions 1-2048; Replicas ≤ broker count;
+// RetentionSeconds 3600-7776000 (1h-90d) or empty for cluster default;
+// RetentionBytes 1-1099511627776 (1 TiB) or -1 for unlimited or empty for default.
+// ClusterId is a path param — exposed via ToRequestBody() returning a body view that strips it.
+type CreateTopicRequest struct {
+	ClusterId        string `json:"-"`
+	Name             string `json:"name"`
+	Partitions       int32  `json:"partitions,omitempty"`
+	Replicas         int32  `json:"replicas,omitempty"`
+	RetentionSeconds int64  `json:"retentionSeconds,omitempty"`
+	RetentionBytes   int64  `json:"retentionBytes,omitempty"`
+	lscommon.UserAgent
+}
+
+// createTopicBody is the wire-level body shape — no embedded UserAgent so that
+// json marshalling stays clean ({name, partitions, replicas, retentionSeconds, retentionBytes}).
+type createTopicBody struct {
+	Name             string `json:"name"`
+	Partitions       int32  `json:"partitions,omitempty"`
+	Replicas         int32  `json:"replicas,omitempty"`
+	RetentionSeconds int64  `json:"retentionSeconds,omitempty"`
+	RetentionBytes   int64  `json:"retentionBytes,omitempty"`
+}
+
+func NewCreateTopicRequest(pclusterId string) ICreateTopicRequest {
+	return &CreateTopicRequest{ClusterId: pclusterId}
+}
+
+func (s *CreateTopicRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+func (s *CreateTopicRequest) GetName() string {
+	return s.Name
+}
+
+func (s *CreateTopicRequest) ToRequestBody() interface{} {
+	return &createTopicBody{
+		Name:             s.Name,
+		Partitions:       s.Partitions,
+		Replicas:         s.Replicas,
+		RetentionSeconds: s.RetentionSeconds,
+		RetentionBytes:   s.RetentionBytes,
+	}
+}
+
+func (s *CreateTopicRequest) WithName(pname string) ICreateTopicRequest {
+	s.Name = pname
+	return s
+}
+
+func (s *CreateTopicRequest) WithPartitions(ppartitions int32) ICreateTopicRequest {
+	s.Partitions = ppartitions
+	return s
+}
+
+func (s *CreateTopicRequest) WithReplicas(preplicas int32) ICreateTopicRequest {
+	s.Replicas = preplicas
+	return s
+}
+
+func (s *CreateTopicRequest) WithRetentionSeconds(pretentionSeconds int64) ICreateTopicRequest {
+	s.RetentionSeconds = pretentionSeconds
+	return s
+}
+
+func (s *CreateTopicRequest) WithRetentionBytes(pretentionBytes int64) ICreateTopicRequest {
+	s.RetentionBytes = pretentionBytes
+	return s
+}

--- a/vngcloud/services/kafka/v1/kafka_response.go
+++ b/vngcloud/services/kafka/v1/kafka_response.go
@@ -1,0 +1,207 @@
+package v1
+
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+
+// KafkaCluster response payload (wire format, matches vdb-api.json KafkaCluster schema).
+type KafkaClusterResponse struct {
+	Id                   string                 `json:"id"`
+	Name                 string                 `json:"name"`
+	Tags                 map[string]string      `json:"tags"`
+	KafkaVersion         string                 `json:"kafkaVersion"`
+	ServerFlavorId       string                 `json:"serverFlavorId"`
+	KafkaBrokerCount     int32                  `json:"kafkaBrokerCount"`
+	KafkaStorageType     string                 `json:"kafkaStorageType"`
+	KafkaStorageSize     int32                  `json:"kafkaStorageSize"`
+	KafkaStorageUsage    []int64                `json:"kafkaStorageUsage"`
+	VserverProjectId     string                 `json:"vserverProjectId"`
+	NetworkId            string                 `json:"networkId"`
+	SubnetId             string                 `json:"subnetId"`
+	FixedIps             []string               `json:"fixedIps"`
+	FloatingIps          []string               `json:"floatingIps"`
+	PublicAccess         bool                   `json:"publicAccess"`
+	MtlsAuthen           bool                   `json:"mtlsAuthen"`
+	SaslAuthen           bool                   `json:"saslAuthen"`
+	SecurityGroupRules   []SecurityGroupRuleDto `json:"securityGroupRules"`
+	ConfigGroupVersionId string                 `json:"configGroupVersionId"`
+	PortalUserId         int32                  `json:"portalUserId"`
+	Status               string                 `json:"status"`
+	ErrorMessage         string                 `json:"errorMessage"`
+	CreatedAt            string                 `json:"createdAt"`
+	EncryptionVolume     bool                   `json:"encryptionVolume"`
+	Iops                 int32                  `json:"iops"`
+	VolumeType           string                 `json:"volumeType"`
+	VolumeTypeZoneId     string                 `json:"volumeTypeZoneId"`
+	Ram                  int32                  `json:"ram"`
+	Vcpus                int32                  `json:"vcpus"`
+	InstanceType         string                 `json:"instanceType"`
+}
+
+type SecurityGroupRuleDto struct {
+	Id             string `json:"id"`
+	Direction      string `json:"direction"`
+	Protocol       string `json:"protocol"`
+	PortRangeMin   int32  `json:"portRangeMin"`
+	PortRangeMax   int32  `json:"portRangeMax"`
+	RemoteIpPrefix string `json:"remoteIpPrefix"`
+}
+
+func (s *KafkaClusterResponse) ToEntity() *lsentity.KafkaCluster {
+	if s == nil {
+		return nil
+	}
+	rules := make([]lsentity.KafkaSecurityGroupRule, 0, len(s.SecurityGroupRules))
+	for _, r := range s.SecurityGroupRules {
+		rules = append(rules, lsentity.KafkaSecurityGroupRule{
+			Id:             r.Id,
+			Direction:      r.Direction,
+			Protocol:       r.Protocol,
+			PortRangeMin:   r.PortRangeMin,
+			PortRangeMax:   r.PortRangeMax,
+			RemoteIpPrefix: r.RemoteIpPrefix,
+		})
+	}
+	return &lsentity.KafkaCluster{
+		Id:                   s.Id,
+		Name:                 s.Name,
+		Tags:                 s.Tags,
+		KafkaVersion:         s.KafkaVersion,
+		ServerFlavorId:       s.ServerFlavorId,
+		KafkaBrokerCount:     s.KafkaBrokerCount,
+		KafkaStorageType:     s.KafkaStorageType,
+		KafkaStorageSize:     s.KafkaStorageSize,
+		KafkaStorageUsage:    s.KafkaStorageUsage,
+		VserverProjectId:     s.VserverProjectId,
+		NetworkId:            s.NetworkId,
+		SubnetId:             s.SubnetId,
+		FixedIps:             s.FixedIps,
+		FloatingIps:          s.FloatingIps,
+		PublicAccess:         s.PublicAccess,
+		MtlsAuthen:           s.MtlsAuthen,
+		SaslAuthen:           s.SaslAuthen,
+		SecurityGroupRules:   rules,
+		ConfigGroupVersionId: s.ConfigGroupVersionId,
+		PortalUserId:         s.PortalUserId,
+		Status:               s.Status,
+		ErrorMessage:         s.ErrorMessage,
+		CreatedAt:            s.CreatedAt,
+		EncryptionVolume:     s.EncryptionVolume,
+		Iops:                 s.Iops,
+		VolumeType:           s.VolumeType,
+		VolumeTypeZoneId:     s.VolumeTypeZoneId,
+		Ram:                  s.Ram,
+		Vcpus:                s.Vcpus,
+		InstanceType:         s.InstanceType,
+	}
+}
+
+type ListClustersResponse []KafkaClusterResponse
+
+func (s ListClustersResponse) ToEntity() []lsentity.KafkaCluster {
+	out := make([]lsentity.KafkaCluster, 0, len(s))
+	for i := range s {
+		out = append(out, *s[i].ToEntity())
+	}
+	return out
+}
+
+// UserDto -----------------------------------------------------------------
+
+type KafkaUserResponse struct {
+	Id                       string   `json:"id"`
+	ClusterId                string   `json:"clusterId"`
+	Name                     string   `json:"name"`
+	ProduceTopicNames        []string `json:"produceTopicNames"`
+	ProduceAll               bool     `json:"produceAll"`
+	ConsumeTopicNames        []string `json:"consumeTopicNames"`
+	ConsumeAll               bool     `json:"consumeAll"`
+	ProduceConsumeTopicNames []string `json:"produceConsumeTopicNames"`
+	ProduceConsumeAll        bool     `json:"produceConsumeAll"`
+	AdminTopicNames          []string `json:"adminTopicNames"`
+	AdminAll                 bool     `json:"adminAll"`
+	MtlsAuthen               bool     `json:"mtlsAuthen"`
+	SaslAuthen               bool     `json:"saslAuthen"`
+	PortalUserId             int32    `json:"portalUserId"`
+	OldStatus                string   `json:"oldStatus"`
+	Status                   string   `json:"status"`
+	CreatedAt                string   `json:"createdAt"`
+}
+
+func (s *KafkaUserResponse) ToEntity() *lsentity.KafkaUser {
+	if s == nil {
+		return nil
+	}
+	return &lsentity.KafkaUser{
+		Id:                       s.Id,
+		ClusterId:                s.ClusterId,
+		Name:                     s.Name,
+		ProduceTopicNames:        s.ProduceTopicNames,
+		ProduceAll:               s.ProduceAll,
+		ConsumeTopicNames:        s.ConsumeTopicNames,
+		ConsumeAll:               s.ConsumeAll,
+		ProduceConsumeTopicNames: s.ProduceConsumeTopicNames,
+		ProduceConsumeAll:        s.ProduceConsumeAll,
+		AdminTopicNames:          s.AdminTopicNames,
+		AdminAll:                 s.AdminAll,
+		MtlsAuthen:               s.MtlsAuthen,
+		SaslAuthen:               s.SaslAuthen,
+		PortalUserId:             s.PortalUserId,
+		OldStatus:                s.OldStatus,
+		Status:                   s.Status,
+		CreatedAt:                s.CreatedAt,
+	}
+}
+
+type ListUsersResponse []KafkaUserResponse
+
+func (s ListUsersResponse) ToEntity() []lsentity.KafkaUser {
+	out := make([]lsentity.KafkaUser, 0, len(s))
+	for i := range s {
+		out = append(out, *s[i].ToEntity())
+	}
+	return out
+}
+
+// TopicDto ----------------------------------------------------------------
+
+type KafkaTopicResponse struct {
+	Id               string `json:"id"`
+	ClusterId        string `json:"clusterId"`
+	Name             string `json:"name"`
+	Partitions       int32  `json:"partitions"`
+	Replicas         int32  `json:"replicas"`
+	RetentionSeconds int64  `json:"retentionSeconds"`
+	RetentionBytes   int64  `json:"retentionBytes"`
+	PortalUserId     int32  `json:"portalUserId"`
+	Status           string `json:"status"`
+	CreatedAt        string `json:"createdAt"`
+}
+
+func (s *KafkaTopicResponse) ToEntity() *lsentity.KafkaTopic {
+	if s == nil {
+		return nil
+	}
+	return &lsentity.KafkaTopic{
+		Id:               s.Id,
+		ClusterId:        s.ClusterId,
+		Name:             s.Name,
+		Partitions:       s.Partitions,
+		Replicas:         s.Replicas,
+		RetentionSeconds: s.RetentionSeconds,
+		RetentionBytes:   s.RetentionBytes,
+		PortalUserId:     s.PortalUserId,
+		Status:           s.Status,
+		CreatedAt:        s.CreatedAt,
+	}
+}
+
+type ListTopicsResponse []KafkaTopicResponse
+
+func (s ListTopicsResponse) ToEntity() []lsentity.KafkaTopic {
+	out := make([]lsentity.KafkaTopic, 0, len(s))
+	for i := range s {
+		out = append(out, *s[i].ToEntity())
+	}
+	return out
+}

--- a/vngcloud/services/kafka/v1/url.go
+++ b/vngcloud/services/kafka/v1/url.go
@@ -1,0 +1,34 @@
+package v1
+
+import lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+
+// Path layout under the vDB Kafka service base URL (/vdb-kafka/...):
+//   clusters
+//   clusters/{clusterId}
+//   clusters/{clusterId}/users
+//   clusters/{clusterId}/users/{userId}/authen-creds
+//   clusters/{clusterId}/topics
+
+func listClustersUrl(psc lsclient.IServiceClient) string {
+	return psc.ServiceURL("clusters")
+}
+
+func getClusterUrl(psc lsclient.IServiceClient, popts IGetClusterRequest) string {
+	return psc.ServiceURL("clusters", popts.GetClusterId())
+}
+
+func listUsersUrl(psc lsclient.IServiceClient, popts IListUsersRequest) string {
+	return psc.ServiceURL("clusters", popts.GetClusterId(), "users")
+}
+
+func getUserAuthenCredsUrl(psc lsclient.IServiceClient, popts IGetUserAuthenCredsRequest) string {
+	return psc.ServiceURL("clusters", popts.GetClusterId(), "users", popts.GetUserId(), "authen-creds")
+}
+
+func listTopicsUrl(psc lsclient.IServiceClient, popts IListTopicsRequest) string {
+	return psc.ServiceURL("clusters", popts.GetClusterId(), "topics")
+}
+
+func createTopicUrl(psc lsclient.IServiceClient, popts ICreateTopicRequest) string {
+	return psc.ServiceURL("clusters", popts.GetClusterId(), "topics")
+}

--- a/vngcloud/services/opensearch/iopensearch.go
+++ b/vngcloud/services/opensearch/iopensearch.go
@@ -1,0 +1,13 @@
+package opensearch
+
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+	lsopensearchSvcV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/opensearch/v1"
+)
+
+type IOpenSearchServiceV1 interface {
+	ListClusters(popts lsopensearchSvcV1.IListClustersRequest) (*[]lsentity.OpenSearchCluster, lserr.IError)
+	GetCluster(popts lsopensearchSvcV1.IGetClusterRequest) (*lsentity.OpenSearchCluster, lserr.IError)
+	ListEndpoints(popts lsopensearchSvcV1.IListEndpointsRequest) (*[]lsentity.OpenSearchEndpoint, lserr.IError)
+}

--- a/vngcloud/services/opensearch/opensearch.go
+++ b/vngcloud/services/opensearch/opensearch.go
@@ -1,0 +1,12 @@
+package opensearch
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsopensearchSvcV1 "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/opensearch/v1"
+)
+
+func NewOpenSearchServiceV1(psvcClient lsclient.IServiceClient) IOpenSearchServiceV1 {
+	return &lsopensearchSvcV1.OpenSearchServiceV1{
+		VopensearchClient: psvcClient,
+	}
+}

--- a/vngcloud/services/opensearch/v1/base.go
+++ b/vngcloud/services/opensearch/v1/base.go
@@ -1,0 +1,9 @@
+package v1
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+)
+
+type OpenSearchServiceV1 struct {
+	VopensearchClient lsclient.IServiceClient
+}

--- a/vngcloud/services/opensearch/v1/irequest.go
+++ b/vngcloud/services/opensearch/v1/irequest.go
@@ -1,0 +1,15 @@
+package v1
+
+type IListClustersRequest interface {
+	ParseUserAgent() string
+}
+
+type IGetClusterRequest interface {
+	GetClusterId() string
+	ParseUserAgent() string
+}
+
+type IListEndpointsRequest interface {
+	GetClusterId() string
+	ParseUserAgent() string
+}

--- a/vngcloud/services/opensearch/v1/opensearch.go
+++ b/vngcloud/services/opensearch/v1/opensearch.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+	lserr "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/sdk_error"
+)
+
+// ListClusters returns every OpenSearch cluster the authenticated portal user
+// owns inside the configured project.
+func (s *OpenSearchServiceV1) ListClusters(popts IListClustersRequest) (*[]lsentity.OpenSearchCluster, lserr.IError) {
+	url := listClustersUrl(s.VopensearchClient)
+	resp := new(ListClustersResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VopensearchClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VopensearchClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters("projectId", s.VopensearchClient.GetProjectId())
+	}
+
+	out := resp.ToEntity()
+	return &out, nil
+}
+
+// ListEndpoints returns the public/private URLs of a cluster.
+// Each cluster typically exposes two URLs:
+//   - type="dashboard" :443   — OpenSearch Dashboards UI
+//   - type="log"       :9200  — REST API (use this for bulk writes / _cluster/health probes)
+func (s *OpenSearchServiceV1) ListEndpoints(popts IListEndpointsRequest) (*[]lsentity.OpenSearchEndpoint, lserr.IError) {
+	url := listEndpointsUrl(s.VopensearchClient, popts)
+	resp := new(ListEndpointsResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VopensearchClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VopensearchClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"projectId", s.VopensearchClient.GetProjectId(),
+				"clusterId", popts.GetClusterId(),
+			)
+	}
+
+	out := resp.ToEntity()
+	return &out, nil
+}
+
+// GetCluster fetches the detailed view of a single OpenSearch cluster.
+// Pass the full UUID from the cluster's `id` field (not the truncated `clusterId`).
+func (s *OpenSearchServiceV1) GetCluster(popts IGetClusterRequest) (*lsentity.OpenSearchCluster, lserr.IError) {
+	url := getClusterUrl(s.VopensearchClient, popts)
+	resp := new(GetClusterResponse)
+	errResp := lserr.NewErrorResponse(lserr.NormalErrorType)
+	req := lsclient.NewRequest().
+		WithHeader("User-Agent", popts.ParseUserAgent()).
+		WithUserId(s.VopensearchClient.GetUserId()).
+		WithOkCodes(200).
+		WithJsonResponse(resp).
+		WithJsonError(errResp)
+
+	if _, sdkErr := s.VopensearchClient.Get(url, req); sdkErr != nil {
+		return nil, lserr.SdkErrorHandler(sdkErr, errResp).
+			WithKVparameters(
+				"projectId", s.VopensearchClient.GetProjectId(),
+				"clusterId", popts.GetClusterId(),
+			)
+	}
+
+	return resp.Data.ToEntity(), nil
+}

--- a/vngcloud/services/opensearch/v1/opensearch_request.go
+++ b/vngcloud/services/opensearch/v1/opensearch_request.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	lscommon "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/services/common"
+)
+
+// ListClustersRequest -----------------------------------------------------
+
+type ListClustersRequest struct {
+	lscommon.UserAgent
+}
+
+func NewListClustersRequest() IListClustersRequest {
+	return &ListClustersRequest{}
+}
+
+// GetClusterRequest -------------------------------------------------------
+
+type GetClusterRequest struct {
+	ClusterId string
+	lscommon.UserAgent
+}
+
+// NewGetClusterRequest takes the full UUID returned in the cluster's `id` field
+// (NOT the truncated `clusterId` field — only `id` works as the URL segment).
+func NewGetClusterRequest(pclusterId string) IGetClusterRequest {
+	return &GetClusterRequest{ClusterId: pclusterId}
+}
+
+func (s *GetClusterRequest) GetClusterId() string {
+	return s.ClusterId
+}
+
+// ListEndpointsRequest ----------------------------------------------------
+
+type ListEndpointsRequest struct {
+	ClusterId string
+	lscommon.UserAgent
+}
+
+func NewListEndpointsRequest(pclusterId string) IListEndpointsRequest {
+	return &ListEndpointsRequest{ClusterId: pclusterId}
+}
+
+func (s *ListEndpointsRequest) GetClusterId() string {
+	return s.ClusterId
+}

--- a/vngcloud/services/opensearch/v1/opensearch_response.go
+++ b/vngcloud/services/opensearch/v1/opensearch_response.go
@@ -1,0 +1,188 @@
+package v1
+
+import (
+	lsentity "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/entity"
+)
+
+// OpenSearchClusterResponse mirrors the wire payload for a single cluster.
+type OpenSearchClusterResponse struct {
+	Id          string `json:"id"`
+	ClusterId   string `json:"clusterId"`
+	ProjectId   string `json:"projectId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Version     string `json:"version"`
+	Region      string `json:"region"`
+
+	NumberOfNodes int32 `json:"numberOfNodes"`
+	StorageSize   int32 `json:"storageSize"`
+
+	EnableTls     bool `json:"enableTls"`
+	PublicAccess  bool `json:"publicAccess"`
+	PrivateAccess bool `json:"privateAccess"`
+	EncryptVolume bool `json:"encryptVolume"`
+	EnableVpcDns  bool `json:"enableVpcDns"`
+
+	VpcId    string `json:"vpcId"`
+	VpcCidr  string `json:"vpcCidr"`
+	SubnetId string `json:"subnetId"`
+
+	PackageId     string `json:"packageId"`
+	StorageTypeId string `json:"storageTypeId"`
+	ConfigGroupId string `json:"configGroupId"`
+	PortalUserId  int32  `json:"portalUserId"`
+
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	DeletedAt string `json:"deletedAt"`
+
+	PackageDetail OpenSearchPackageDetailDto `json:"packageDetail"`
+	StorageType   OpenSearchStorageTypeDto   `json:"storageType"`
+	ConfigGroup   OpenSearchConfigGroupDto   `json:"configGroup"`
+	BillingStatus OpenSearchBillingStatusDto `json:"billingStatus"`
+}
+
+type OpenSearchPackageDetailDto struct {
+	Id                 string `json:"id"`
+	Name               string `json:"name"`
+	Type               string `json:"type"`
+	Description        string `json:"description"`
+	NetworkPerformance string `json:"networkPerformance"`
+	IsDefault          bool   `json:"isDefault"`
+	Ram                int32  `json:"ram"`
+	Cpu                int32  `json:"cpu"`
+	Platform           string `json:"platform"`
+}
+
+type OpenSearchStorageTypeDto struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Min  int32  `json:"min"`
+	Max  int32  `json:"max"`
+}
+
+type OpenSearchConfigGroupDto struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type OpenSearchBillingStatusDto struct {
+	Status      string `json:"status"`
+	RenewPeriod int32  `json:"renewPeriod"`
+}
+
+// ListClustersResponse wraps the list endpoint payload:
+//
+//	{ "listData": [...], "page": 0, "pageSize": 0, "totalPage": 0, "totalItem": 0 }
+type ListClustersResponse struct {
+	ListData  []OpenSearchClusterResponse `json:"listData"`
+	Page      int32                       `json:"page"`
+	PageSize  int32                       `json:"pageSize"`
+	TotalPage int32                       `json:"totalPage"`
+	TotalItem int32                       `json:"totalItem"`
+}
+
+// GetClusterResponse wraps { "data": {...} }.
+type GetClusterResponse struct {
+	Data OpenSearchClusterResponse `json:"data"`
+}
+
+func (s *OpenSearchClusterResponse) ToEntity() *lsentity.OpenSearchCluster {
+	if s == nil {
+		return nil
+	}
+	return &lsentity.OpenSearchCluster{
+		Id:            s.Id,
+		ClusterId:     s.ClusterId,
+		ProjectId:     s.ProjectId,
+		Name:          s.Name,
+		Description:   s.Description,
+		Status:        s.Status,
+		Version:       s.Version,
+		Region:        s.Region,
+		NumberOfNodes: s.NumberOfNodes,
+		StorageSize:   s.StorageSize,
+		EnableTls:     s.EnableTls,
+		PublicAccess:  s.PublicAccess,
+		PrivateAccess: s.PrivateAccess,
+		EncryptVolume: s.EncryptVolume,
+		EnableVpcDns:  s.EnableVpcDns,
+		VpcId:         s.VpcId,
+		VpcCidr:       s.VpcCidr,
+		SubnetId:      s.SubnetId,
+		PackageId:     s.PackageId,
+		StorageTypeId: s.StorageTypeId,
+		ConfigGroupId: s.ConfigGroupId,
+		PortalUserId:  s.PortalUserId,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+		DeletedAt:     s.DeletedAt,
+		PackageDetail: lsentity.OpenSearchPackageDetail{
+			Id:                 s.PackageDetail.Id,
+			Name:               s.PackageDetail.Name,
+			Type:               s.PackageDetail.Type,
+			Description:        s.PackageDetail.Description,
+			NetworkPerformance: s.PackageDetail.NetworkPerformance,
+			IsDefault:          s.PackageDetail.IsDefault,
+			Ram:                s.PackageDetail.Ram,
+			Cpu:                s.PackageDetail.Cpu,
+			Platform:           s.PackageDetail.Platform,
+		},
+		StorageType: lsentity.OpenSearchStorageType{
+			Id:   s.StorageType.Id,
+			Name: s.StorageType.Name,
+			Min:  s.StorageType.Min,
+			Max:  s.StorageType.Max,
+		},
+		ConfigGroup: lsentity.OpenSearchConfigGroup{
+			Name:    s.ConfigGroup.Name,
+			Version: s.ConfigGroup.Version,
+		},
+		BillingStatus: lsentity.OpenSearchBillingStatus{
+			Status:      s.BillingStatus.Status,
+			RenewPeriod: s.BillingStatus.RenewPeriod,
+		},
+	}
+}
+
+func (s *ListClustersResponse) ToEntity() []lsentity.OpenSearchCluster {
+	out := make([]lsentity.OpenSearchCluster, 0, len(s.ListData))
+	for i := range s.ListData {
+		out = append(out, *s.ListData[i].ToEntity())
+	}
+	return out
+}
+
+// OpenSearchEndpointResponse mirrors one element of the /endpoints payload.
+type OpenSearchEndpointResponse struct {
+	Url     string   `json:"url"`
+	Type    string   `json:"type"` // "dashboard" (:443) | "log" (:9200)
+	Cidrs   []string `json:"cidrs"`
+	Private bool     `json:"private"`
+}
+
+// ListEndpointsResponse wraps { "data": [...] }.
+type ListEndpointsResponse struct {
+	Data []OpenSearchEndpointResponse `json:"data"`
+}
+
+func (s *OpenSearchEndpointResponse) ToEntity() *lsentity.OpenSearchEndpoint {
+	if s == nil {
+		return nil
+	}
+	return &lsentity.OpenSearchEndpoint{
+		Url:     s.Url,
+		Type:    s.Type,
+		Cidrs:   s.Cidrs,
+		Private: s.Private,
+	}
+}
+
+func (s *ListEndpointsResponse) ToEntity() []lsentity.OpenSearchEndpoint {
+	out := make([]lsentity.OpenSearchEndpoint, 0, len(s.Data))
+	for i := range s.Data {
+		out = append(out, *s.Data[i].ToEntity())
+	}
+	return out
+}

--- a/vngcloud/services/opensearch/v1/url.go
+++ b/vngcloud/services/opensearch/v1/url.go
@@ -1,0 +1,19 @@
+package v1
+
+import lsclient "github.com/vngcloud/vngcloud-go-sdk/v2/vngcloud/client"
+
+// URL layout under base = https://vdb.console.vngcloud.vn/vdb/open-search/v1
+//   /{projectId}/open-search           — list clusters
+//   /{projectId}/open-search/{id}      — get cluster detail
+
+func listClustersUrl(psc lsclient.IServiceClient) string {
+	return psc.ServiceURL(psc.GetProjectId(), "open-search")
+}
+
+func getClusterUrl(psc lsclient.IServiceClient, popts IGetClusterRequest) string {
+	return psc.ServiceURL(psc.GetProjectId(), "open-search", popts.GetClusterId())
+}
+
+func listEndpointsUrl(psc lsclient.IServiceClient, popts IListEndpointsRequest) string {
+	return psc.ServiceURL(psc.GetProjectId(), "open-search", popts.GetClusterId(), "endpoints")
+}


### PR DESCRIPTION
- 6 methods on IKafkaServiceV1: ListClusters, GetCluster, ListUsers, GetUserAuthenCreds (binary ZIP), ListTopics, CreateTopic
- ParseAuthenCredsZip helper: extract PEM bytes for mTLS + SCRAM creds for SASL from the authen-creds zip (drops Java keystore artifacts)
- BuildBootstrapServers helper: assemble "ip:port,ip:port" from KafkaCluster + AuthMode (V1 public endpoint only: mTLS=9194, SASL=9196)
- Extend IRequest with WithBytesResponse for binary endpoints
- Wire VDBKafkaGateway + WithVdbKafkaEndpoint into top-level Client
- Tests: 9 unit tests (helpers) + 6 integration tests against real vDB